### PR TITLE
fix_sloghandler_duplicate_attrs

### DIFF
--- a/internal/logger/sloghandler.go
+++ b/internal/logger/sloghandler.go
@@ -87,7 +87,7 @@ func (h *groupedLogHandler) Enabled(ctx context.Context, level slog.Level) bool 
 }
 
 func (h *groupedLogHandler) Handle(ctx context.Context, record slog.Record) error {
-	// Format grouped attributes
+	// Collect grouped attributes
 	groupedAttrs := make([]slog.Attr, 0, record.NumAttrs())
 	record.Attrs(func(attr slog.Attr) bool {
 		groupedAttrs = append(groupedAttrs, slog.Attr{
@@ -97,9 +97,12 @@ func (h *groupedLogHandler) Handle(ctx context.Context, record slog.Record) erro
 		return true
 	})
 
-	// Pass record with grouped attributes to the original handler
+	// Pass only the modified attributes to the original handler
 	clonedHandler := h.original.WithAttrs(groupedAttrs)
-	return clonedHandler.Handle(ctx, record)
+	return clonedHandler.Handle(ctx, slog.Record{
+		Level:   record.Level,
+		Message: record.Message,
+	})
 }
 
 func (h *groupedLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/internal/logger/sloghandler_test.go
+++ b/internal/logger/sloghandler_test.go
@@ -20,6 +20,79 @@ func TestLogHandler(t *testing.T) {
 		indent         bool
 	}{
 		{
+			name: "Info log without attributes",
+			logFunc: func() {
+				logger.Info("Application started")
+			},
+			expectedOutput: `ℹ Application started`,
+			indent:         false,
+		},
+		{
+			name: "Warning log with attributes",
+			logFunc: func() {
+				logger.Warn("Low disk space",
+					slog.String("disk", "C:"),
+					slog.Int("available_gb", 5),
+				)
+			},
+			expectedOutput: `⚠ Low disk space
+  - disk: C:
+  - available_gb: 5`,
+			indent: false,
+		},
+		{
+			name: "Error log with attributes",
+			logFunc: func() {
+				logger.Error("Unexpected crash",
+					slog.String("module", "auth"),
+					slog.String("reason", "panic"),
+				)
+			},
+			expectedOutput: `✘ Unexpected crash
+  - module: auth
+  - reason: panic`,
+			indent: false,
+		},
+		{
+			name: "Default log level (debug equivalent)",
+			logFunc: func() {
+				logger.Debug("Debugging log")
+			},
+			expectedOutput: `Debugging log`, // No icon for default level
+			indent:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := testutils.CaptureStdout(tt.logFunc)
+			if err != nil {
+				t.Fatalf("Failed to capture stdout: %v", err)
+			}
+
+			// Trim spaces for cleaner comparison
+			output = strings.TrimSpace(output)
+			expected := strings.TrimSpace(tt.expectedOutput)
+
+			if output != expected {
+				t.Errorf("Unexpected output:\nGot: %q\nWant: %q", output, expected)
+			}
+		})
+	}
+}
+
+func TestLogHandlerWithAttrs(t *testing.T) {
+	loggerInstance := NewDefaultLogger()
+	handler := NewLogHandler(loggerInstance)
+	logger := slog.New(handler)
+
+	tests := []struct {
+		name           string
+		logFunc        func()
+		expectedOutput string
+		indent         bool
+	}{
+		{
 			name: "Log message with attributes",
 			logFunc: func() {
 				logger.Info("Starting application",
@@ -50,5 +123,95 @@ func TestLogHandler(t *testing.T) {
 				t.Errorf("Unexpected output:\nGot: %q\nWant: %q", output, expected)
 			}
 		})
+	}
+}
+
+func TestLogHandlerWithGroup(t *testing.T) {
+	loggerInstance := NewDefaultLogger()
+	handler := NewLogHandler(loggerInstance)
+
+	// Use WithGroup to create a grouped handler
+	groupedHandler := handler.WithGroup("database")
+	logger := slog.New(groupedHandler)
+
+	output, err := testutils.CaptureStdout(func() {
+		logger.Warn("Connection slow",
+			slog.String("latency", "500ms"),
+		)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	expectedOutput := `⚠ Connection slow
+  - database.latency: 500ms`
+
+	output = strings.TrimSpace(output)
+	expectedOutput = strings.TrimSpace(expectedOutput)
+
+	if output != expectedOutput {
+		t.Errorf("Unexpected output:\nGot: %q\nWant: %q", output, expectedOutput)
+	}
+}
+
+func TestGroupedLogHandlerWithAttrs(t *testing.T) {
+	loggerInstance := NewDefaultLogger()
+	handler := NewLogHandler(loggerInstance)
+
+	// Create a grouped handler
+	groupedHandler := handler.WithGroup("database")
+
+	// Create a new handler with additional attributes
+	newHandler := groupedHandler.WithAttrs([]slog.Attr{
+		slog.String("query", "SELECT * FROM users"),
+		slog.Int("execution_time", 120),
+	})
+
+	logger := slog.New(newHandler)
+
+	output, err := testutils.CaptureStdout(func() {
+		logger.Info("Query executed")
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	expectedOutput := `ℹ Query executed
+  - database.query: SELECT * FROM users
+  - database.execution_time: 120`
+
+	output = strings.TrimSpace(output)
+	expectedOutput = strings.TrimSpace(expectedOutput)
+
+	if output != expectedOutput {
+		t.Errorf("Unexpected output:\nGot: %q\nWant: %q", output, expectedOutput)
+	}
+}
+
+func TestGroupedLogHandlerWithNestedGroups(t *testing.T) {
+	loggerInstance := NewDefaultLogger()
+	handler := NewLogHandler(loggerInstance)
+
+	// Create a nested grouped handler
+	groupedHandler := handler.WithGroup("database").WithGroup("connection")
+	logger := slog.New(groupedHandler)
+
+	output, err := testutils.CaptureStdout(func() {
+		logger.Warn("Slow response",
+			slog.String("latency", "500ms"),
+		)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	expectedOutput := `⚠ Slow response
+  - database.connection.latency: 500ms`
+
+	output = strings.TrimSpace(output)
+	expectedOutput = strings.TrimSpace(expectedOutput)
+
+	if output != expectedOutput {
+		t.Errorf("Unexpected output:\nGot: %q\nWant: %q", output, expectedOutput)
 	}
 }


### PR DESCRIPTION
This PR fixes an issue with the `sloghandler` in the `logger` package where duplicate attributes were being added to the grouped log handler. 

It also expands the test suite for `sloghandler `