### PR TITLE
fix(newcmd): prevent action processing in dry-run mode

### DIFF
--- a/cmd/tempo/newcmd/new.go
+++ b/cmd/tempo/newcmd/new.go
@@ -117,6 +117,8 @@ func setupNewComponentSubCommand(cmdCtx *app.AppContext, flags []cli.Flag) *cli.
 
 			if data.DryRun {
 				cmdCtx.Logger.Info("Dry Run Mode: No changes will be made.\n")
+				cmdCtx.Logger.Reset()
+				return nil
 			}
 
 			// Step 2: Check if "define component" command has been executed
@@ -148,17 +150,16 @@ func setupNewComponentSubCommand(cmdCtx *app.AppContext, flags []cli.Flag) *cli.
 			}
 
 			// Step 5: Log success and asset information
-			if !data.DryRun {
-				componentPath := filepath.Join(data.GoPackage, data.ComponentName)
-				assetPath := filepath.Join(data.AssetsDir, data.ComponentName)
+			componentPath := filepath.Join(data.GoPackage, data.ComponentName)
+			assetPath := filepath.Join(data.AssetsDir, data.ComponentName)
 
-				cmdCtx.Logger.Success("Templ component files have been created").
-					WithAttrs(
-						"component", data.ComponentName,
-						"component_path", componentPath,
-						"asset_path", assetPath,
-					)
-			}
+			cmdCtx.Logger.Success("Templ component files have been created").
+				WithAttrs(
+					"component", data.ComponentName,
+					"component_path", componentPath,
+					"asset_path", assetPath,
+				)
+
 			cmdCtx.Logger.Reset()
 
 			return nil

--- a/cmd/tempo/newcmd/new_test.go
+++ b/cmd/tempo/newcmd/new_test.go
@@ -1029,7 +1029,11 @@ func TestNewComponent_UnwritableDirectory(t *testing.T) {
 	if err := os.Chmod(componentDir, 0000); err != nil {
 		t.Fatalf("Failed to make directory unwritable: %v", err)
 	}
-	defer os.Chmod(componentDir, 0755) // Ensure cleanup after test
+	defer func() {
+		if err := os.Chmod(componentDir, 0755); err != nil {
+			t.Errorf("Failed to restore permissions on %s: %v", componentDir, err)
+		}
+	}()
 
 	cliCtx := &app.AppContext{
 		Logger: logger.NewDefaultLogger(),


### PR DESCRIPTION
This PR fixes an issue in the `newcmd` feature, where actions were being processed even in **dry-run** mode.