### PR TITLE
sync-summary-format

### DIFF
--- a/cmd/tempo/initcmd/init.go
+++ b/cmd/tempo/initcmd/init.go
@@ -155,7 +155,7 @@ func writeConfigFile(filePath string, cfg *config.Config) error {
 	sb.WriteString("processor:\n")
 	sb.WriteString("  # Number of concurrent workers (numCPUs * 2).\n")
 	sb.WriteString(fmt.Sprintf("  workers: %d\n\n", cfg.Processor.Workers))
-	sb.WriteString("  # Summary format: text, json, none.\n")
+	sb.WriteString("  # Summary format: compact, long, json, none.\n")
 	sb.WriteString(fmt.Sprintf("  summary_format: %s\n\n", cfg.Processor.SummaryFormat))
 
 	// Write templates configuration

--- a/cmd/tempo/newcmd/new.go
+++ b/cmd/tempo/newcmd/new.go
@@ -378,17 +378,35 @@ func createVariantData(cmd *cli.Command, cfg *config.Config) (*generator.Templat
 
 // createBaseTemplateData initializes common fields for TemplateData.
 func createBaseTemplateData(cmd *cli.Command, cfg *config.Config) (*generator.TemplateData, error) {
-	moduleName, err := resolver.ResolveString(cmd.String("module"), cfg.App.GoModule, "module name")
+	moduleName, err := resolver.ResolveString(
+		cmd.String("module"),
+		cfg.App.GoModule,
+		"module name",
+		"",
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	packageName, err := resolver.ResolveString(cmd.String("package"), cfg.App.GoPackage, "package")
+	packageName, err := resolver.ResolveString(
+		cmd.String("package"),
+		cfg.App.GoPackage,
+		"package",
+		config.DefaultGoPackage,
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	assetsDir, err := resolver.ResolveString(cmd.String("assets"), cfg.App.AssetsDir, "assets folder")
+	assetsDir, err := resolver.ResolveString(
+		cmd.String("assets"),
+		cfg.App.AssetsDir,
+		"assets folder",
+		config.DefaultAssetsDir,
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tempo/registercmd/register.go
+++ b/cmd/tempo/registercmd/register.go
@@ -114,9 +114,9 @@ func resolveFlagsToTemplateFuncProvider(cmd *cli.Command) ([]config.TemplateFunc
 	var providers []config.TemplateFuncProvider
 
 	// Resolve values with priority: CLI > Config
-	name, _ := resolver.ResolveString(cmd.String("name"), "", "provider name")
-	url, _ := resolver.ResolveString(cmd.String("url"), "", "repository URL")
-	path, _ := resolver.ResolveString(cmd.String("path"), "", "local path")
+	name, _ := resolver.ResolveString(cmd.String("name"), "", "provider name", "", nil)
+	url, _ := resolver.ResolveString(cmd.String("url"), "", "repository URL", "", nil)
+	path, _ := resolver.ResolveString(cmd.String("path"), "", "local path", "", nil)
 
 	if name == "" {
 		if url != "" {

--- a/cmd/tempo/synccmd/sync.go
+++ b/cmd/tempo/synccmd/sync.go
@@ -102,7 +102,7 @@ func getFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:    "summary",
 			Aliases: []string{"s"},
-			Usage:   "Summary format: text, json, compact, none (default: text)",
+			Usage:   "Summary format: compact, long, json, none (default: compact)",
 		},
 		&cli.BoolFlag{
 			Name:  "verbose-summary",

--- a/cmd/tempo/synccmd/sync.go
+++ b/cmd/tempo/synccmd/sync.go
@@ -372,10 +372,8 @@ func handleSummary(
 		return errors.Wrap("Failed to generate summary", err)
 	}
 
-	// Print to stdout
-	if summaryOpts.Format == "text" || summaryOpts.Format == "json" {
-		logger.Default(summary)
-	}
+	// Print summary
+	logger.Default(summary)
 
 	// Handle Summary Export to JSON File
 	if summaryOpts.ReportFile != "" {

--- a/cmd/tempo/synccmd/sync.go
+++ b/cmd/tempo/synccmd/sync.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/indaco/tempo/internal/app"
+	"github.com/indaco/tempo/internal/config"
 	"github.com/indaco/tempo/internal/errors"
 	"github.com/indaco/tempo/internal/helpers"
 	"github.com/indaco/tempo/internal/logger"
@@ -284,12 +285,24 @@ func resolveSyncFlags(
 	cmd *cli.Command,
 	cmdCtx *app.AppContext,
 ) (worker.WorkerPoolOptions, *worker.SummaryOptions, error) {
-	inputDir, err := resolver.ResolveString(cmd.String("input"), cmdCtx.Config.App.AssetsDir, "input folder")
+	inputDir, err := resolver.ResolveString(
+		cmd.String("input"),
+		cmdCtx.Config.App.AssetsDir,
+		"input folder",
+		config.DefaultAssetsDir,
+		nil,
+	)
 	if err != nil {
 		return worker.WorkerPoolOptions{}, nil, err
 	}
 
-	outputDir, err := resolver.ResolveString(cmd.String("output"), cmdCtx.Config.App.GoPackage, "output folder")
+	outputDir, err := resolver.ResolveString(
+		cmd.String("output"),
+		cmdCtx.Config.App.GoPackage,
+		"output folder",
+		config.DefaultGoPackage,
+		nil,
+	)
 	if err != nil {
 		return worker.WorkerPoolOptions{}, nil, err
 	}
@@ -318,7 +331,13 @@ func resolveSyncFlags(
 	}
 
 	// Summary options
-	summaryFormat, err := resolver.ResolveString(cmd.String("summary"), cmdCtx.Config.Processor.SummaryFormat, "summary")
+	summaryFormat, err := resolver.ResolveString(
+		cmd.String("summary"),
+		cmdCtx.Config.Processor.SummaryFormat,
+		"summary",
+		config.DefaultSummaryFormat,
+		[]string{"compact", "long", "json", "none"},
+	)
 	if err != nil {
 		return worker.WorkerPoolOptions{}, nil, err
 	}

--- a/cmd/tempo/synccmd/sync_test.go
+++ b/cmd/tempo/synccmd/sync_test.go
@@ -504,7 +504,7 @@ func TestResolveSyncFlags(t *testing.T) {
 				IsProduction: false,
 			},
 			expectedSummary: worker.SummaryOptions{
-				Format:     worker.SummaryFormat("long"), // Default from config
+				Format:     worker.SummaryFormat("compact"), // Default from config
 				ReportFile: "",
 			},
 			expectedForce: false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ const (
 	DefaultGoPackage        = "components"
 	DefaultAssetsDir        = "assets"
 	DefaultCssLayer         = "components"
-	DefaultSummaryFormat    = "long"
+	DefaultSummaryFormat    = "compact"
 	DefaultGuardMarkText    = "tempo"
 	DefaultWatermarkTipFlag = true
 )

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,7 +26,7 @@ func TestDefaultConfig(t *testing.T) {
 		},
 		Processor: Processor{
 			Workers:       runtime.NumCPU() * 2,
-			SummaryFormat: "long",
+			SummaryFormat: "compact",
 		},
 		Templates: Templates{
 			Extensions:        DefaultTemplateExtensions,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -10,28 +10,54 @@ import (
 	"github.com/indaco/tempo/internal/templatefuncs/providers/textprovider"
 )
 
-// ResolveString determines the final string value by preferring the CLI flag over
-// the configuration value. If both are empty, it returns an error indicating that
-// the field is required.
+// ResolveString determines the final string value by prioritizing the CLI flag over
+// the configuration value. It validates the resolved value against allowed options
+// and falls back to a default if necessary.
+//
+// If both the CLI and configuration values are empty, an error is returned, indicating
+// that the field is required. If an invalid value is provided, the default value
+// is silently returned.
 //
 // Parameters:
 //   - cliValue: The value provided via CLI flag (if any).
-//   - configValue: The value from the configuration file.
+//   - configValue: The value from the configuration file (if any).
 //   - fieldName: The name of the field being resolved (used for error messages).
+//   - defaultValue: The fallback value if neither cliValue nor configValue are valid.
+//   - allowedValues: A list of permitted values for validation.
 //
 // Returns:
-//   - The resolved string value (either cliValue or configValue).
-//   - An error if both values are empty, indicating that the field is required.
-func ResolveString(cliValue, configValue, fieldName string) (string, error) {
+//   - The resolved string value (cliValue, configValue, or defaultValue).
+//   - An error if both values are empty or an invalid value is provided.
+func ResolveString(cliValue, configValue, fieldName, defaultValue string, allowedValues []string) (string, error) {
+	// If both CLI and config values are empty, return the default if it's provided
 	if textprovider.IsEmptyString(cliValue) && textprovider.IsEmptyString(configValue) {
-		return "", errors.Wrap("%s is required. Ensure to pass it as a flag or set its value in .tempo.yaml file", fieldName)
+		if textprovider.IsEmptyString(defaultValue) {
+			// If no default value exists, return an error
+			return "", errors.Wrap("%s is required. Ensure to pass it as a flag or set its value in .tempo.yaml file", fieldName)
+		}
 	}
 
+	// If allowedValues is empty/nil, we skip validation (used for unrestricted fields like directories)
+	shouldValidate := len(allowedValues) > 0
+
+	// Use CLI value if provided
 	if !textprovider.IsEmptyString(cliValue) {
+		if shouldValidate && !textprovider.IsValidValue(cliValue, allowedValues) {
+			return defaultValue, nil // Use default if invalid
+		}
 		return cliValue, nil
 	}
 
-	return configValue, nil
+	// Use config value if provided
+	if !textprovider.IsEmptyString(configValue) {
+		if shouldValidate && !textprovider.IsValidValue(configValue, allowedValues) {
+			return defaultValue, nil // Use default if invalid
+		}
+		return configValue, nil
+	}
+
+	// Default fallback
+	return defaultValue, nil
 }
 
 // ResolveInt determines the final integer value by prioritizing the CLI flag over

--- a/internal/templatefuncs/providers/textprovider/funcs.go
+++ b/internal/templatefuncs/providers/textprovider/funcs.go
@@ -2,6 +2,7 @@ package textprovider
 
 import (
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -9,6 +10,11 @@ import (
 // IsEmptyString checks if a string is empty.
 func IsEmptyString(s string) bool {
 	return s == ""
+}
+
+// IsValidValue checks if a given value is in the allowedValues list.
+func IsValidValue(value string, allowedValues []string) bool {
+	return slices.Contains(allowedValues, value)
 }
 
 // NormalizePath normalizes a path by removing dots, leading/trailing slashes, and white spaces.

--- a/internal/templatefuncs/providers/textprovider/funcs_test.go
+++ b/internal/templatefuncs/providers/textprovider/funcs_test.go
@@ -23,6 +23,97 @@ func TestIsEmptyString(t *testing.T) {
 	}
 }
 
+func TestIsValidValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		allowed  []string
+		expected bool
+	}{
+		{
+			name:     "Valid value - long",
+			value:    "long",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: true,
+		},
+		{
+			name:     "Valid value - compact",
+			value:    "compact",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: true,
+		},
+		{
+			name:     "Valid value - json",
+			value:    "json",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: true,
+		},
+		{
+			name:     "Valid value - none",
+			value:    "none",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: true,
+		},
+		{
+			name:     "Invalid value - empty string",
+			value:    "",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: false,
+		},
+		{
+			name:     "Invalid value - typo",
+			value:    "lonng",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: false,
+		},
+		{
+			name:     "Invalid value - completely wrong",
+			value:    "invalid",
+			allowed:  []string{"long", "compact", "json", "none"},
+			expected: false,
+		},
+		{
+			name:     "Valid in different set",
+			value:    "high",
+			allowed:  []string{"low", "medium", "high"},
+			expected: true,
+		},
+		{
+			name:     "Invalid in different set",
+			value:    "extreme",
+			allowed:  []string{"low", "medium", "high"},
+			expected: false,
+		},
+		{
+			name:     "Valid value - single option",
+			value:    "single",
+			allowed:  []string{"single"},
+			expected: true,
+		},
+		{
+			name:     "Invalid value - single option mismatch",
+			value:    "wrong",
+			allowed:  []string{"single"},
+			expected: false,
+		},
+		{
+			name:     "No allowed values",
+			value:    "anything",
+			allowed:  []string{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidValue(tt.value, tt.allowed)
+			if result != tt.expected {
+				t.Errorf("IsValidValue(%q, %v) = %v; want %v", tt.value, tt.allowed, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizePath(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This PR includes the following changes:

1. Set `compact` as the default summary format for the sync feature. This change simplifies the output and makes it more concise.

2. Refactor the `ResolveString` function to improve the validation handling. The `allowedValues` parameter is now used to ensure that the input values are within the expected range.

3. Improve the summary output handling for the `sync` command.
