### PR TITLE
Standardize hooks, Makefile, and Taskfile for testing, linting, and modernization

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,10 +6,14 @@ echo '* Verify dependencies'
 go mod verify
 
 echo ""
+echo '* Run: go-modernize'
+modernize -test ./...
+
+echo ""
 echo '* Run: golangci'
 golangci-lint run ./...
 
 echo ""
 echo '* Run: all tests and generate coverage report'
 go clean -testcache
-go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'testutils|internal/templates') -covermode=atomic
+go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'internal/testhelpers|internal/testutils|internal/templates') -covermode=atomic

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,10 +6,14 @@ echo '* Verify dependencies'
 go mod verify
 
 echo ""
+echo '* Run: go-modernize'
+modernize -test ./...
+
+echo ""
 echo '* Run: golangci'
 golangci-lint run ./...
 
 echo ""
 echo '* Run: all tests and generate coverage report'
 go clean -testcache
-go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'testutils|internal/templates') -covermode=atomic
+go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'internal/testhelpers|internal/testutils|internal/templates') -covermode=atomic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: '**'
+    branches: "**"
   pull_request:
-    branches: '**'
+    branches: "**"
   workflow_dispatch:
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
           check-latest: true
 
       - name: Install Go modules
@@ -28,7 +28,7 @@ jobs:
         run: go mod verify
 
       - name: Run tests
-        run: go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'testutils|internal/templates') -covermode=atomic
+        run: go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'internal/testhelpers|internal/testutils|internal/templates') -covermode=atomic
 
   golangci:
     name: lint
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
           check-latest: true
 
       - name: Install Go modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ To set up a development environment for this repository, you can use [devbox](ht
 1. Install devbox by following [these instructions](https://www.jetify.com/devbox/docs/installing_devbox/).
 2. Clone this repository to your local machine.
 
-    ```bash
-    git clone https://github.com/indaco/tempo.git
-    cd tempo
-    ```
+   ```bash
+   git clone https://github.com/indaco/tempo.git
+   cd tempo
+   ```
 
 3. Run `devbox install` to install all dependencies specified in `devbox.json`.
 4. Enter the environment with `devbox shell --pure`.
@@ -24,8 +24,9 @@ To set up a development environment for this repository, you can use [devbox](ht
 
 If you prefer not to use Devbox, ensure you have the following tools installed:
 
-- `golangci-lint`: For linting Go code.
-- `go-task` or `make`: For running project tasks.
+- [golangci-lint](https://golangci-lint.run/): For linting Go code.
+- [go-task](https://taskfile.dev/) or `make`: For running project tasks.
+- [modernize](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize): Run the modernizer analyzer to simplify code by using modern constructs.
 
 ## Setting Up Git Hooks
 
@@ -41,24 +42,24 @@ For users not using `devbox`, follow the steps below to manually install the Git
 
 1. Clone the repository:
 
-    ```bash
-    git clone https://github.com/indaco/tempo.git
-    cd tempo
-    ```
+   ```bash
+   git clone https://github.com/indaco/tempo.git
+   cd tempo
+   ```
 
 2. Install the Git Hooks
 
-    **Unix-based systems (Linux, macOS):**
+   **Unix-based systems (Linux, macOS):**
 
-    ```bash
-    sh .scripts/setup-hooks.sh
-    ```
+   ```bash
+   sh .scripts/setup-hooks.sh
+   ```
 
-    **Windows systems:**
+   **Windows systems:**
 
-    ```cmd
-    .scripts\setup-hooks.bat
-    ```
+   ```cmd
+   .scripts\setup-hooks.bat
+   ```
 
 ## Running Tasks
 
@@ -76,7 +77,9 @@ build:               # Build the binary
 clean:               # Clean the build directory and Go cache
 default:             # Run clean and build tasks
 install:             # Install the binary using Go install
+lint:                # Run golangci-lint
+modernize:           # Run go-modernize
 test:                # Run all tests and generate coverage report
 test/coverage:       # Run go tests and use go tool cover
-test/force:          # Clean go tests cache
+test/force:          # Clean go tests cache and run all tests
 ```

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,19 @@ test/coverage: ## Run go tests and use go tool cover.
 
 .PHONY: test/force
 test/force: ## Clean go tests cache.
-	@echo "$(color_bold_cyan)* Clean go tests cache.$(color_reset)"
+	@echo "$(color_bold_cyan)* Clean go tests cache and run all tests.$(color_reset)"
 	@$(GO) clean -testcache
 	@$(MAKE) test
+
+.PHONY: modernize
+modernize: ## Run go-modernize
+	@echo "$(color_bold_cyan)* Running go-modernize$(color_reset)"
+	@modernize -test ./...
+
+.PHONY: lint
+lint: ## Run golangci-lint
+	@echo "$(color_bold_cyan)* Running golangci-lint$(color_reset)"
+	@golangci-lint run ./...
 
 .PHONY: build
 build: ## Build the binary with development metadata
@@ -83,6 +93,8 @@ build: ## Build the binary with development metadata
 
 .PHONY: install
 install: ## Install the binary using Go install
+	@$(MAKE) modernize
+	@$(MAKE) lint
 	@$(MAKE) test/force
 	@echo "$(color_bold_cyan)* Install the binary using Go install$(color_reset)"
 	@cd $(CMD_DIR) && $(GO) install .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,11 +51,23 @@ tasks:
       - task: test/view-coverage
 
   test/force:
-    desc: Clean go tests cache.
+    desc: Clean go tests cache and run all tests.
     silent: false
     cmds:
       - go clean -testcache
       - task: test
+
+  modernize:
+    desc: Run go-modernize
+    silent: false
+    cmds:
+      - modernize -test ./...
+
+  lint:
+    desc: Run golangci-lint
+    silent: false
+    cmds:
+      - golangci-lint run ./...
 
   build:
     desc: "Building the binary..."
@@ -68,6 +80,8 @@ tasks:
     desc: "Install the binary using Go install"
     silent: false
     deps:
+      - modernize
+      - lint
       - test/force
     cmds:
       - cd {{.CMD_DIR}} && go install .

--- a/devbox.json
+++ b/devbox.json
@@ -1,25 +1,27 @@
 {
-	"$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.0/.schema/devbox.schema.json",
-	"packages": [
-		"git@latest",
-		"go@1.23",
-		"golangci-lint@latest",
-		"go-task@latest",
-		"gnumake@latest"
-	],
-	"env": {
-		"GOPATH": "$HOME/go/",
-		"PATH": "$PATH:$HOME/go/bin"
-	},
-	"shell": {
-		"init_hook": [
-			"echo '\nWelcome to the Tempo devbox!\n'",
-			"echo '* Set GOROOT'",
-			"export GOROOT=$(go env GOROOT)",
-			"echo '* Set Git hooks path\n'",
-			"find .githooks -type f -exec chmod +x {} \\;",
-			"git config core.hooksPath .githooks"
-		],
-		"scripts": {}
-	}
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.0/.schema/devbox.schema.json",
+  "packages": [
+    "git@latest",
+    "go@1.23",
+    "golangci-lint@latest",
+    "go-task@latest",
+    "gnumake@latest"
+  ],
+  "env": {
+    "GOPATH": "$HOME/go/",
+    "PATH": "$PATH:$HOME/go/bin"
+  },
+  "shell": {
+    "init_hook": [
+      "echo '\nWelcome to the Tempo devbox!\n'",
+      "echo '* Set GOROOT'",
+      "export GOROOT=$(go env GOROOT)",
+      "echo '* Set Git hooks path\n'",
+      "find .githooks -type f -exec chmod +x {} \\;",
+      "git config core.hooksPath .githooks",
+      "echo '* Install go-modernize",
+      "go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest"
+    ],
+    "scripts": {}
+  }
 }

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -358,7 +358,7 @@ func TestSummaryAsJSON(t *testing.T) {
 	}
 
 	// Normalize and compare JSON objects
-	var expectedObj, resultObj map[string]interface{}
+	var expectedObj, resultObj map[string]any
 
 	if err := json.Unmarshal([]byte(expectedJSON), &expectedObj); err != nil {
 		t.Fatalf("Failed to unmarshal expected JSON: %v", err)


### PR DESCRIPTION
This PR ensures a uniform workflow for running tests, modernize, and golangci-lint across different execution environments:


- Git hooks (`pre-commit` and `pre-push`) now enforce a consistent validation process before commits and pushes.
- `Makefile` and `Taskfile` are aligned to provide the same commands for testing, linting, and modernization.
- `CONTRIBUTING.md` has been updated to reflect these changes.
- `devbox.json` adjustments to include `modernize` installation.