### PR TITLE
get-module-name

### DIFF
--- a/cmd/tempo/initcmd/init.go
+++ b/cmd/tempo/initcmd/init.go
@@ -40,7 +40,7 @@ func SetupInitCommand(cmdCtx *app.AppContext) *cli.Command {
 			tempoConfigPath := filepath.Join(userBaseFolder, configFileName)
 
 			// Step 2: ensure configuration file does not already exist
-			if err := validateInitPrerequisites(tempoConfigPath); err != nil {
+			if err := validateInitPrerequisites(cmdCtx.CWD, tempoConfigPath); err != nil {
 				return err
 			}
 
@@ -83,8 +83,16 @@ func getFlags() []cli.Flag {
 
 // validateInitPrerequisites ensures all the prerequisites for the init command are satisfied.
 //
-// - configuration file does not already exist.
-func validateInitPrerequisites(configFilePath string) error {
+// - A valid go.mod file must be present.
+// - Configuration file does not already exist.
+func validateInitPrerequisites(workingDir, configFilePath string) error {
+	goModPath := filepath.Join(workingDir, "go.mod")
+	if _, err := os.Stat(goModPath); os.IsNotExist(err) {
+		return errors.Wrap("missing go.mod file. Run 'go mod init' to create one")
+	} else if err != nil {
+		return errors.Wrap("error checking go.mod file", err)
+	}
+
 	exists, err := utils.FileExistsFunc(configFilePath)
 	if err != nil {
 		return errors.Wrap("Error checking configuration file", err)

--- a/cmd/tempo/main_test.go
+++ b/cmd/tempo/main_test.go
@@ -101,6 +101,14 @@ func TestRunApp_Help(t *testing.T) {
 func TestRunApp_InitAutoGen(t *testing.T) {
 	// Create a temporary directory that does not contain a config file.
 	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	goModPath := filepath.Join(tempDir, "go.mod")
+	err := os.WriteFile(goModPath, []byte("module example.com/myproject\n\ngo 1.23\n"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
 	configPath := filepath.Join(tempDir, "tempo.yaml")
 	os.Remove(configPath) // Ensure it's missing.
 

--- a/cmd/tempo/newcmd/new_test.go
+++ b/cmd/tempo/newcmd/new_test.go
@@ -315,7 +315,7 @@ func TestNewCommandVariant_WithFlags(t *testing.T) {
 	cliCtx := &app.AppContext{
 		Logger: logger.NewDefaultLogger(),
 		Config: cfg,
-		CWD:    t.TempDir(),
+		CWD:    tempDir,
 	}
 
 	// Write `tempo.yaml` to the current working directory
@@ -341,38 +341,38 @@ func TestNewCommandVariant_WithFlags(t *testing.T) {
 	})
 
 	// Step 2: Run "new component" to test the command
-	// t.Run("Component with configs by flags", func(t *testing.T) {
-	// 	output, err := testhelpers.CaptureStdout(func() {
-	// 		args := []string{
-	// 			"tempo",
-	// 			"new",
-	// 			"component",
-	// 			"--package", cfg.App.GoPackage,
-	// 			"--name", "custom-component",
-	// 			"--assets", cfg.App.AssetsDir,
-	// 		}
-	// 		if err := app.Run(context.Background(), args); err != nil {
-	// 			t.Fatalf("Unexpected error: %v", err)
-	// 		}
-	// 	})
+	t.Run("Component with configs by flags", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo",
+				"new",
+				"component",
+				"--package", cfg.App.GoPackage,
+				"--name", "custom-component",
+				"--assets", cfg.App.AssetsDir,
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
 
-	// 	if err != nil {
-	// 		t.Fatalf("Failed to capture stdout: %v", err)
-	// 	}
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
 
-	// 	testhelpers.ValidateCLIOutput(t, output, []string{
-	// 		"✔ Templ component files have been created",
-	// 	})
+		testhelpers.ValidateCLIOutput(t, output, []string{
+			"✔ Templ component files have been created",
+		})
 
-	// 	//Transform name using the same logic as in the implementation
-	// 	transformedName := gonameprovider.ToGoPackageName("custom-component")
-	// 	expectedFiles := []string{
-	// 		filepath.Join(cfg.App.GoPackage, transformedName, fmt.Sprintf("%s.templ", transformedName)),
-	// 		filepath.Join(cfg.App.GoPackage, transformedName, "css", "base.templ"),
-	// 		filepath.Join(cfg.App.AssetsDir, transformedName, "css", "base.css"),
-	// 	}
-	// 	testutils.ValidateGeneratedFiles(t, expectedFiles)
-	// })
+		//Transform name using the same logic as in the implementation
+		transformedName := gonameprovider.ToGoPackageName("custom-component")
+		expectedFiles := []string{
+			filepath.Join(cfg.App.GoPackage, transformedName, fmt.Sprintf("%s.templ", transformedName)),
+			filepath.Join(cfg.App.GoPackage, transformedName, "css", "base.templ"),
+			filepath.Join(cfg.App.AssetsDir, transformedName, "css", "base.css"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
 
 	// Step 3: Run "define variant" to set up the required folder structure and files
 	t.Run("Define Variant Setup", func(t *testing.T) {
@@ -390,57 +390,97 @@ func TestNewCommandVariant_WithFlags(t *testing.T) {
 	})
 
 	// Step 4: Run "new variant" to test the command
-	// t.Run("Variant with custom flags", func(t *testing.T) {
-	// 	output, err := testhelpers.CaptureStdout(func() {
-	// 		args := []string{
-	// 			"tempo",
-	// 			"new",
-	// 			"variant",
-	// 			"--module", "custom-module",
-	// 			"--package", cfg.App.GoPackage,
-	// 			"--name", "secondary",
-	// 			"--component", "custom-component",
-	// 			"--assets", cfg.App.AssetsDir,
-	// 		}
-	// 		if err := app.Run(context.Background(), args); err != nil {
-	// 			t.Fatalf("Unexpected error: %v", err)
-	// 		}
-	// 	})
+	t.Run("Variant with custom flags", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo",
+				"new",
+				"variant",
+				"--package", cfg.App.GoPackage,
+				"--name", "secondary",
+				"--component", "custom-component",
+				"--assets", cfg.App.AssetsDir,
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
 
-	// 	if err != nil {
-	// 		t.Fatalf("Failed to capture stdout: %v", err)
-	// 	}
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
 
-	// 	// Validate CLI output
-	// 	testhelpers.ValidateCLIOutput(t, output, []string{
-	// 		"✔ Templ component for the variant and asset files (CSS) have been created",
-	// 	})
+		// Validate CLI output
+		testhelpers.ValidateCLIOutput(t, output, []string{
+			"✔ Templ component for the variant and asset files (CSS) have been created",
+		})
 
-	// 	// Transform name using the same logic as in the implementation
-	// 	transformedName := gonameprovider.ToGoPackageName("secondary")
+		// Transform name using the same logic as in the implementation
+		transformedName := gonameprovider.ToGoPackageName("secondary")
 
-	// 	// Validate generated files
-	// 	expectedFiles := []string{
-	// 		filepath.Join(cfg.App.GoPackage, "custom_component", "css", "variants", fmt.Sprintf("%s.templ", transformedName)),
-	// 		filepath.Join(cfg.App.AssetsDir, "custom_component", "css", "variants", fmt.Sprintf("%s.css", transformedName)),
-	// 	}
-	// 	testutils.ValidateGeneratedFiles(t, expectedFiles)
-	// })
+		// Validate generated files
+		expectedFiles := []string{
+			filepath.Join(cfg.App.GoPackage, "custom_component", "css", "variants", fmt.Sprintf("%s.templ", transformedName)),
+			filepath.Join(cfg.App.AssetsDir, "custom_component", "css", "variants", fmt.Sprintf("%s.css", transformedName)),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+}
+
+func TestNewCommandComponent_FailsOnMissingGoMod(t *testing.T) {
+	tempDir := t.TempDir() // Create a temporary directory without go.mod
+
+	cfg := setupConfig(tempDir, nil)
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Ensure go.mod does NOT exist
+	goModPath := filepath.Join(tempDir, "go.mod")
+	if _, err := os.Stat(goModPath); !os.IsNotExist(err) {
+		t.Fatalf("go.mod file should NOT exist for this test case")
+	}
+
+	// Prepare CLI app
+	appCmd := &cli.Command{
+		Before: validateNewPrerequisites(cliCtx.CWD),
+		Commands: []*cli.Command{
+			definecmd.SetupDefineCommand(cliCtx),
+			SetupNewCommand(cliCtx),
+		},
+	}
+
+	// Try running the command
+	err := appCmd.Run(context.Background(), []string{"tempo", "new", "component", "--name", "button"})
+
+	// Validate error
+	if err == nil {
+		t.Fatal("Expected error due to missing go.mod, but got none")
+	}
+
+	expectedErrorMsg := "missing go.mod file. Run 'go mod init' to create one"
+	if !strings.Contains(err.Error(), expectedErrorMsg) {
+		t.Errorf("Unexpected error message. Expected: %q, got: %q", expectedErrorMsg, err.Error())
+	}
 }
 
 func TestHandleEntityExistence(t *testing.T) {
 	tests := []struct {
-		name       string
-		entityType string
-		entityName string
-		outputPath string
-		force      bool
-		shouldWarn bool
+		name         string
+		entityType   string
+		entityName   string
+		outputPath   string
+		force        bool
+		shouldWarn   bool
+		expectedPath string
 	}{
-		{"Component Exists Without Force", "component", "button", "/mock/path/button", false, true},
-		{"Component Exists With Force", "component", "button", "/mock/path/button", true, false},
-		{"Variant Exists Without Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", false, true},
-		{"Variant Exists With Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", true, false},
+		{"Component Exists Without Force", "component", "button", "/mock/path/button", false, true, "/mock/path/button/button"},
+		{"Component Exists With Force", "component", "button", "/mock/path/button", true, false, "/mock/path/button/button"},
+		{"Variant Exists Without Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", false, true, "/mock/path/button/css/variants/outline.templ"},
+		{"Variant Exists With Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", true, false, "/mock/path/button/css/variants/outline.templ"},
+		{"Unknown Entity Type", "unknown", "mystery", "/mock/path/unknown", false, true, "/mock/path/unknown"}, // NEW CASE
 	}
 
 	for _, tc := range tests {
@@ -454,6 +494,7 @@ func TestHandleEntityExistence(t *testing.T) {
 				t.Fatalf("Failed to capture stdout: %v", err)
 			}
 
+			// Verify the warning or overwrite messages
 			if tc.shouldWarn {
 				if !strings.Contains(output, "Use '--force' to overwrite it.") {
 					t.Errorf("Expected warning message, got: %s", output)
@@ -462,6 +503,11 @@ func TestHandleEntityExistence(t *testing.T) {
 				if !strings.Contains(output, "Overwriting due to '--force' flag.") {
 					t.Errorf("Expected overwrite message, got: %s", output)
 				}
+			}
+
+			// Check if the correct path was used in the log output
+			if !strings.Contains(output, tc.expectedPath) {
+				t.Errorf("Expected path %q in output, but got: %s", tc.expectedPath, output)
 			}
 		})
 	}
@@ -772,6 +818,119 @@ func TestNewCommandComponent_DryRun(t *testing.T) {
 	})
 }
 
+func TestNewCommandVariant_DryRun(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := setupConfig(tempDir, nil)
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Write `tempo.yaml` to the current working directory
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create mock config file: %v", err)
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			definecmd.SetupDefineCommand(cliCtx),
+			SetupNewCommand(cliCtx),
+		},
+	}
+
+	// Step 1: Run "define component" to set up the required folder structure and files
+	t.Run("Define Component", func(t *testing.T) {
+		_, err := testutils.SetupDefineComponent(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component", "templ", "component.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "component.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 2: Run "new component" to test the command
+	t.Run("Create new component with default config", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo", "new", "component",
+				"--name", "button",
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		testhelpers.ValidateCLIOutput(t, output, []string{
+			"✔ Templ component files have been created",
+		})
+
+		expectedFiles := []string{
+			filepath.Join(cfg.App.GoPackage, "button", "button.templ"),
+			filepath.Join(cfg.App.GoPackage, "button", "css", "base.templ"),
+			filepath.Join(cfg.App.AssetsDir, "button", "css", "base.css"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 3: Run "define variant" to set up the required folder structure and files
+	t.Run("Define Variant Setup", func(t *testing.T) {
+		_, err := testutils.SetupDefineVariant(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Validate that the "define variant" command generated the expected files
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	//Step 4: Run "new variant" to test the command
+	t.Run("Variant with default config", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo",
+				"new",
+				"variant",
+				"--name", "neon",
+				"--component", "button",
+				"--dry-run",
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Check that the output contains the dry run message.
+		if !strings.Contains(output, "Dry Run Mode: No changes will be made.") {
+			t.Errorf("Expected dry run message in output, got: %s", output)
+		}
+	})
+}
+
 // createTestComponentCmd returns the CLI command for creating a component.
 func createTestComponentCmd(cliCtx *app.AppContext) *cli.Command {
 	return SetupNewCommand(cliCtx).Commands[0] // component subcommand
@@ -880,7 +1039,7 @@ func TestNewVariant_AlreadyExists_NoForce(t *testing.T) {
 		t.Fatalf("Failed to create go.mod file: %v", err)
 	}
 
-	cfg := config.DefaultConfig()
+	cfg := setupConfig(tempDir, nil)
 	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
 	cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
 	cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
@@ -1215,5 +1374,150 @@ func TestNewComponent_DryRun_NoChanges(t *testing.T) {
 	expectedFailureMsg := "failed to process actions"
 	if utils.ContainsSubstring(output, expectedFailureMsg) {
 		t.Errorf("Unexpected error during dry-run: %q", output)
+	}
+}
+
+func TestValidateNewComponentPrerequisites_ErrorOnCheckMissingFolders(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := setupConfig(tempDir, nil)
+
+	// Mock `CheckMissingFoldersFunc` to simulate a missing folder error
+	originalFunc := utils.CheckMissingFoldersFunc
+	defer func() { utils.CheckMissingFoldersFunc = originalFunc }() // Restore after test
+
+	utils.CheckMissingFoldersFunc = func(folders map[string]string) ([]string, error) {
+		return []string{"  - Templates directory: /mock/path/component"}, fmt.Errorf("mock error in CheckMissingFolders")
+	}
+
+	validate := validateNewComponentPrerequisites(cfg)
+	_, err := validate(context.Background(), &cli.Command{})
+
+	if err == nil {
+		t.Fatal("Expected an error due to CheckMissingFolders failure, but got nil")
+	}
+
+	// Instead of checking for the mock error, check that the error message contains "Missing folders"
+	expectedSubstring := "Missing folders:"
+	if !strings.Contains(err.Error(), expectedSubstring) {
+		t.Errorf("Expected error message to contain %q, but got %q", expectedSubstring, err.Error())
+	}
+}
+
+func TestCreateBaseTemplateData_DefaultValues(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := setupConfig(tempDir, nil)
+
+	appCmd := &cli.Command{
+		Flags: getCoreFlags(),
+	}
+
+	// Call function without setting any flags
+	data, err := createBaseTemplateData(appCmd, cfg)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+
+	// Verify defaults
+	if data.GoPackage != cfg.App.GoPackage {
+		t.Errorf("Expected default GoPackage, got: %s", data.GoPackage)
+	}
+	if data.AssetsDir != cfg.App.AssetsDir {
+		t.Errorf("Expected default AssetsDir, got: %s", data.AssetsDir)
+	}
+	if data.WithJs != cfg.App.WithJs {
+		t.Errorf("Expected default WithJs value, got: %v", data.WithJs)
+	}
+	if data.Force != false {
+		t.Errorf("Expected default Force to be false, got: %v", data.Force)
+	}
+	if data.DryRun != false {
+		t.Errorf("Expected default DryRun to be false, got: %v", data.DryRun)
+	}
+}
+
+func TestResolveActionFilePath(t *testing.T) {
+	tempDir := t.TempDir()
+	actionsDir := filepath.Join(tempDir, "actions")
+	existingFile := filepath.Join(actionsDir, "existing.json")
+	nonExistentFile := filepath.Join(tempDir, "nonexistent.json")
+	mockError := fmt.Errorf("mock error")
+
+	tests := []struct {
+		name           string
+		actionsDir     string
+		actionFileFlag string
+		mockFileExists func(path string) (bool, error)
+		expectedErr    string
+		expectedResult string
+	}{
+		{
+			name:           "Action file found in ActionsDir",
+			actionsDir:     actionsDir,
+			actionFileFlag: "existing.json",
+			mockFileExists: func(path string) (bool, error) {
+				if path == existingFile {
+					return true, nil
+				}
+				return false, nil
+			},
+			expectedResult: existingFile,
+		},
+		{
+			name:           "Action file does not exist",
+			actionsDir:     "",
+			actionFileFlag: nonExistentFile,
+			mockFileExists: func(path string) (bool, error) {
+				return false, nil
+			},
+			expectedErr: "action file does not exist",
+		},
+		{
+			name:           "Error checking resolvedPath",
+			actionsDir:     actionsDir,
+			actionFileFlag: "error.json",
+			mockFileExists: func(path string) (bool, error) {
+				if strings.Contains(path, actionsDir) {
+					return false, mockError
+				}
+				return false, nil
+			},
+			expectedErr: "mock error",
+		},
+		{
+			name:           "Error checking absolute path",
+			actionsDir:     "",
+			actionFileFlag: nonExistentFile,
+			mockFileExists: func(path string) (bool, error) {
+				if path == nonExistentFile {
+					return false, mockError
+				}
+				return false, nil
+			},
+			expectedErr: "error checking action file path",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock the function
+			utils.FileExistsFunc = tc.mockFileExists
+			defer func() { utils.FileExistsFunc = utils.FileExists }() // Reset after test
+
+			result, err := resolveActionFilePath(tc.actionsDir, tc.actionFileFlag)
+
+			if tc.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("Expected error %q, but got: %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if result != tc.expectedResult {
+					t.Fatalf("Expected result %q, but got %q", tc.expectedResult, result)
+				}
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/indaco/tempo-api v0.0.0-20250217085709-fd62d35b4d54
 	github.com/urfave/cli/v3 v3.0.0-beta1
+	golang.org/x/mod v0.24.0
 	golang.org/x/sync v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjcw9Zg=
 github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
 golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,6 @@ func DefaultConfig() *Config {
 	return &Config{
 		TempoRoot: DefaultBaseDir,
 		App: App{
-			GoModule:  "github.com/example/demotempo",
 			GoPackage: DefaultGoPackage,
 			WithJs:    false,
 			CssLayer:  DefaultCssLayer,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,6 @@ func TestDefaultConfig(t *testing.T) {
 	expected := &Config{
 		TempoRoot: DefaultBaseDir,
 		App: App{
-			GoModule:  "github.com/example/demotempo",
 			GoPackage: "components",
 			WithJs:    false,
 			CssLayer:  "components",
@@ -114,9 +113,6 @@ func TestEnsureDefaults(t *testing.T) {
 	defaultConfig := DefaultConfig()
 	customConfig := &Config{
 		TempoRoot: "custom-tempo",
-		App: App{
-			GoModule: "github.com/custom/module",
-		},
 		Templates: Templates{
 			GuardMarker: "custom-marker",
 		},
@@ -127,7 +123,6 @@ func TestEnsureDefaults(t *testing.T) {
 	expected := &Config{
 		TempoRoot: "custom-tempo",
 		App: App{
-			GoModule:  "github.com/custom/module",
 			GoPackage: "components",
 			WithJs:    false,
 			CssLayer:  "components",

--- a/internal/generator/action.go
+++ b/internal/generator/action.go
@@ -195,6 +195,9 @@ func renderActionFolder(action Action, data *TemplateData) error {
 /* UTILITY FUNCTIONS                                                         */
 /* ------------------------------------------------------------------------- */
 
+// LoadUserActionsFunc is a function variable to allow testing overrides.
+var LoadUserActionsFunc = LoadUserActions
+
 // LoadUserActions reads an actions.json file and parses it into a slice of JSONAction structs.
 func LoadUserActions(filePath string) ([]JSONAction, error) {
 	// Check if the file exists and is not a directory

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/indaco/tempo/internal/config"
@@ -24,4 +25,14 @@ func ValidateGeneratedFiles(t *testing.T, paths []string) {
 			t.Errorf("Expected file not found: %s", path)
 		}
 	}
+}
+
+func CreateModFile(tempDir string) error {
+	// Create go.mod inside tempDir (the correct working directory)
+	goModPath := filepath.Join(tempDir, "go.mod")
+	err := os.WriteFile(goModPath, []byte("module example.com/myproject\n\ngo 1.23\n"), 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 
 	"github.com/indaco/tempo/internal/errors"
+	"golang.org/x/mod/modfile"
 )
 
 /* ------------------------------------------------------------------------- */
@@ -244,4 +245,23 @@ func RebasePathToOutput(inputPath, inputDir, outputDir string) string {
 
 	// Convert to `.templ` extension
 	return ToTemplFilename(newPath)
+}
+
+// GetModuleName extracts the module name from the go.mod file.
+func GetModuleName(goModPath string) (string, error) {
+	content, err := os.ReadFile(goModPath)
+	if err != nil {
+		return "", errors.Wrap("error reading go.mod file")
+	}
+
+	parsedModFile, err := modfile.Parse(goModPath, content, nil)
+	if err != nil {
+		return "", errors.Wrap("error parsing go.mod file")
+	}
+
+	if parsedModFile.Module == nil || parsedModFile.Module.Mod.Path == "" {
+		return "", errors.Wrap("module path not found in go.mod file")
+	}
+
+	return parsedModFile.Module.Mod.Path, nil
 }

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -249,19 +249,25 @@ func RebasePathToOutput(inputPath, inputDir, outputDir string) string {
 
 // GetModuleName extracts the module name from the go.mod file.
 func GetModuleName(goModPath string) (string, error) {
-	content, err := os.ReadFile(goModPath)
+	goModFile := filepath.Join(goModPath, "go.mod")
+	fmt.Printf("DEBUG: Checking go.mod at %s\n", goModFile)
+	content, err := os.ReadFile(goModFile)
 	if err != nil {
-		return "", errors.Wrap("error reading go.mod file")
+		fmt.Printf("DEBUG: Error reading go.mod file: %v\n", err)
+		return "", errors.Wrap("error reading go.mod file", err)
 	}
 
-	parsedModFile, err := modfile.Parse(goModPath, content, nil)
+	parsedModFile, err := modfile.Parse(goModFile, content, nil)
 	if err != nil {
-		return "", errors.Wrap("error parsing go.mod file")
+		fmt.Printf("DEBUG: Error parsing go.mod file: %v\n", err)
+		return "", errors.Wrap("error parsing go.mod file", err)
 	}
 
 	if parsedModFile.Module == nil || parsedModFile.Module.Mod.Path == "" {
+		fmt.Println("DEBUG: Module path not found in go.mod file")
 		return "", errors.Wrap("module path not found in go.mod file")
 	}
 
+	fmt.Printf("DEBUG: Found module name: %s\n", parsedModFile.Module.Mod.Path)
 	return parsedModFile.Module.Mod.Path, nil
 }

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -130,6 +130,9 @@ func RemoveIfExists(path string) error {
 	return nil
 }
 
+// CheckMissingFoldersFunc is a function variable to allow testing overrides.
+var CheckMissingFoldersFunc = CheckMissingFolders
+
 // CheckMissingFolders validates folder paths and returns a list of missing folders.
 func CheckMissingFolders(folders map[string]string) ([]string, error) {
 	var missingFolders []string
@@ -250,24 +253,19 @@ func RebasePathToOutput(inputPath, inputDir, outputDir string) string {
 // GetModuleName extracts the module name from the go.mod file.
 func GetModuleName(goModPath string) (string, error) {
 	goModFile := filepath.Join(goModPath, "go.mod")
-	fmt.Printf("DEBUG: Checking go.mod at %s\n", goModFile)
 	content, err := os.ReadFile(goModFile)
 	if err != nil {
-		fmt.Printf("DEBUG: Error reading go.mod file: %v\n", err)
 		return "", errors.Wrap("error reading go.mod file", err)
 	}
 
 	parsedModFile, err := modfile.Parse(goModFile, content, nil)
 	if err != nil {
-		fmt.Printf("DEBUG: Error parsing go.mod file: %v\n", err)
 		return "", errors.Wrap("error parsing go.mod file", err)
 	}
 
 	if parsedModFile.Module == nil || parsedModFile.Module.Mod.Path == "" {
-		fmt.Println("DEBUG: Module path not found in go.mod file")
 		return "", errors.Wrap("module path not found in go.mod file")
 	}
 
-	fmt.Printf("DEBUG: Found module name: %s\n", parsedModFile.Module.Mod.Path)
 	return parsedModFile.Module.Mod.Path, nil
 }


### PR DESCRIPTION
This PR includes the following changes:

1. Removed the `watermark` configuration and related code.
2. Validated the existence of the `go.mod` file during the `init` command.
3. Added a feature to get the module name from the `go.mod` file.
4. Refactored the `newcmd` to check for the `go.mod` file in the validation.