### PR TITLE
fix/template-files-and-css-layers

### DIFF
--- a/cmd/tempo/initcmd/init.go
+++ b/cmd/tempo/initcmd/init.go
@@ -128,7 +128,6 @@ func prepareConfig(workingDir, tempoRoot, templatesDir, actionsDir string) (*con
 			GoModule:  moduleName,
 			GoPackage: config.DefaultGoPackage,
 			AssetsDir: config.DefaultAssetsDir,
-			CssLayer:  config.DefaultCssLayer,
 		},
 		Paths: config.Paths{
 			TemplatesDir: templatesDir,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,6 @@ const (
 	DefaultBaseDir       = ".tempo-files"
 	DefaultGoPackage     = "components"
 	DefaultAssetsDir     = "assets"
-	DefaultCssLayer      = "components"
 	DefaultSummaryFormat = "compact"
 	DefaultGuardMarkText = "tempo"
 )
@@ -87,7 +86,6 @@ func DefaultConfig() *Config {
 		App: App{
 			GoPackage: DefaultGoPackage,
 			WithJs:    false,
-			CssLayer:  DefaultCssLayer,
 			AssetsDir: DefaultAssetsDir,
 		},
 		Paths: Paths{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,7 +16,6 @@ func TestDefaultConfig(t *testing.T) {
 		App: App{
 			GoPackage: "components",
 			WithJs:    false,
-			CssLayer:  "components",
 			AssetsDir: "assets",
 		},
 		Paths: Paths{
@@ -125,7 +124,6 @@ func TestEnsureDefaults(t *testing.T) {
 		App: App{
 			GoPackage: "components",
 			WithJs:    false,
-			CssLayer:  "components",
 			AssetsDir: "assets",
 		},
 		Paths: Paths{

--- a/internal/templatefuncs/providers/textprovider/funcs.go
+++ b/internal/templatefuncs/providers/textprovider/funcs.go
@@ -9,7 +9,7 @@ import (
 
 // IsEmptyString checks if a string is empty.
 func IsEmptyString(s string) bool {
-	return s == ""
+	return strings.TrimSpace(s) == ""
 }
 
 // IsValidValue checks if a given value is in the allowedValues list.

--- a/internal/templatefuncs/providers/textprovider/funcs_test.go
+++ b/internal/templatefuncs/providers/textprovider/funcs_test.go
@@ -10,7 +10,7 @@ func TestIsEmptyString(t *testing.T) {
 	}{
 		{"Empty string", "", true},
 		{"Non-empty string", "hello", false},
-		{"String with spaces", "   ", false},
+		{"String with spaces", "   ", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/templates/component/assets/css/base.css.gotxt
+++ b/internal/templates/component/assets/css/base.css.gotxt
@@ -1,4 +1,4 @@
-{{- if isEmpty .CssLayer }}
+{{- if isEmpty .CssLayer -}}
 :root {
 
 }
@@ -8,4 +8,4 @@
 
   }
 }
-{{- end }}
+{{- end -}}

--- a/internal/templates/component/assets/css/themes/dark.css.gotxt
+++ b/internal/templates/component/assets/css/themes/dark.css.gotxt
@@ -1,4 +1,4 @@
-{{- if isEmpty .CssLayer }}
+{{- if isEmpty .CssLayer -}}
 @media (prefers-color-scheme: dark) {
   :root {
 
@@ -10,7 +10,7 @@ html[data-theme='dark'],
 body.dark {
 
 }
-{{- else }}
+{{- else -}}
 @layer {{ .CssLayer }} {
   @media (prefers-color-scheme: dark) {
     :root {
@@ -24,4 +24,4 @@ body.dark {
 
   }
 }
-{{- end }}
+{{- end -}}

--- a/internal/templates/component/assets/css/themes/light.css.gotxt
+++ b/internal/templates/component/assets/css/themes/light.css.gotxt
@@ -1,11 +1,11 @@
-{{- if isEmpty .CssLayer }}
+{{- if isEmpty .CssLayer -}}
 :root {
 
 }
-{{- else }}
+{{- else -}}
 @layer {{ .CssLayer }} {
   :root {
 
   }
 }
-{{- end }}
+{{- end -}}

--- a/internal/templates/component/assets/js/script.js.gotxt
+++ b/internal/templates/component/assets/js/script.js.gotxt
@@ -1,2 +1,1 @@
-{{- if .WatermarkTip -}}// JS file for '{{ .ComponentName | goUnexportedName }}'
-// The content of this file will be processed and transferred to '{{ .ComponentName | goPackageName }}/js/script.templ'{{ end }}
+// JS file for '{{ .ComponentName | goUnexportedName }}'


### PR DESCRIPTION
ThisPR addresses the following changes:

1. Fixes an issue in the `text-provider` module where the `IsEmptyString` function did not properly handle strings with spaces.
2. Removes an unused `CssLayer` configuration from the codebase.
3. Fixes the CSS template files by removing unnecessary whitespace.
