### PR TITLE
refactor(utils): update CheckMissingFolders to return map instead of slice

### DIFF
--- a/cmd/tempo/componentcmd/new.go
+++ b/cmd/tempo/componentcmd/new.go
@@ -146,7 +146,7 @@ func runComponentNewSubCommand(cmdCtx *app.AppContext) func(ctx context.Context,
 func validateComponentNewPrerequisites(cfg *config.Config) func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 		foldersToCheck := map[string]string{
-			"Templates directory": filepath.Join(cfg.Paths.TemplatesDir, "component"),
+			"templates_directory": filepath.Join(cfg.Paths.TemplatesDir, "component"),
 		}
 
 		missingFolders, err := utils.CheckMissingFolders(foldersToCheck)
@@ -157,8 +157,8 @@ func validateComponentNewPrerequisites(cfg *config.Config) func(ctx context.Cont
 		if len(missingFolders) > 0 {
 			return nil, helpers.BuildMissingFoldersError(
 				missingFolders,
-				"Have you run 'tempo define' or 'tempo create' to set up your components?\nMake sure your templates, actions, and implementations exist before creating a new component.",
-				[]string{"tempo define -h", "tempo create -h"},
+				"Have you run 'tempo component define' or 'tempo component new' to set up your components?\nMake sure your templates, actions, and implementations exist before creating a new component.",
+				[]string{"tempo component -h"},
 			)
 		}
 

--- a/cmd/tempo/synccmd/sync_test.go
+++ b/cmd/tempo/synccmd/sync_test.go
@@ -21,20 +21,6 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func setupConfig(tempDir string, overrides func(cfg *config.Config)) *config.Config {
-	cfg := config.DefaultConfig()
-	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
-	cfg.App.GoPackage = filepath.Join(tempDir, "components")
-	cfg.App.AssetsDir = filepath.Join(tempDir, "assets")
-	cfg.Paths.TemplatesDir = filepath.Join(cfg.TempoRoot, "templates")
-	cfg.Paths.ActionsDir = filepath.Join(cfg.TempoRoot, "actions")
-
-	if overrides != nil {
-		overrides(cfg)
-	}
-	return cfg
-}
-
 func TestSyncCommand(t *testing.T) {
 	tempDir := os.TempDir()
 	inputDir := filepath.Join(tempDir, "input")
@@ -46,7 +32,7 @@ func TestSyncCommand(t *testing.T) {
 	}
 
 	// Setup CLI config
-	cfg := setupConfig(tempDir, nil)
+	cfg := testutils.SetupConfig(tempDir, nil)
 
 	// Write `tempo.yaml`
 	configPath := filepath.Join(tempDir, "tempo.yaml")

--- a/cmd/tempo/variantcmd/new.go
+++ b/cmd/tempo/variantcmd/new.go
@@ -26,7 +26,7 @@ func setupVariantNewSubCommand(cmdCtx *app.AppContext) *cli.Command {
 		UseShortOptionHandling: true,
 		Flags:                  flags,
 		ArgsUsage:              "[--package value | -p] [--assets value | -a] [--name value | -n] [--component value | -c] [--force] [--dry-run]",
-		Before:                 validateNewVariantPrerequisites(cmdCtx.Config),
+		Before:                 validateVariantNewPrerequisites(cmdCtx.Config),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			helpers.EnableLoggerIndentation(cmdCtx.Logger)
 
@@ -49,7 +49,7 @@ func setupVariantNewSubCommand(cmdCtx *app.AppContext) *cli.Command {
 				return err
 			}
 			if !exists {
-				return errors.Wrap("Cannot find actions folder. Did you run 'tempo define variant' before?")
+				return errors.Wrap("Cannot find actions folder. Did you run 'tempo variant define' before?")
 			}
 
 			// Step 3: Ensure the component folder exists before adding a variant
@@ -156,15 +156,15 @@ func getNewFlags() []cli.Flag {
 /* Prerequisites Validation                                                  */
 /* ------------------------------------------------------------------------- */
 
-// validateNewVariantPrerequisites checks prerequisites for the "new variant" subcommand, including:
+// validateVariantNewPrerequisites checks prerequisites for the "new variant" subcommand, including:
 // - Initialized Tempo project (inherited from the main define command).
 // - Existence of the component templates folder.
 // - Existence of the variant templates folder.
-func validateNewVariantPrerequisites(cfg *config.Config) func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+func validateVariantNewPrerequisites(cfg *config.Config) func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 		foldersToCheck := map[string]string{
-			"Component directory": filepath.Join(cfg.Paths.TemplatesDir, "component"),
-			"Variant directory":   filepath.Join(cfg.Paths.TemplatesDir, "component-variant"),
+			"component_directory": filepath.Join(cfg.Paths.TemplatesDir, "component"),
+			"variant_directory":   filepath.Join(cfg.Paths.TemplatesDir, "component-variant"),
 		}
 
 		missingFolders, err := utils.CheckMissingFolders(foldersToCheck)
@@ -175,8 +175,8 @@ func validateNewVariantPrerequisites(cfg *config.Config) func(ctx context.Contex
 		if len(missingFolders) > 0 {
 			return nil, helpers.BuildMissingFoldersError(
 				missingFolders,
-				"Have you run 'tempo define' or 'tempo create' to set up your components?\nMake sure your templates, actions, and implementations exist before creating a new variant.",
-				[]string{"tempo define -h", "tempo create -h"},
+				"Have you run 'tempo component define' or 'tempo variant define' to set up your components?\nMake sure your templates, actions, and implementations exist before creating a new variant.",
+				[]string{"tempo component -h", "tempo define -h"},
 			)
 		}
 

--- a/cmd/tempo/variantcmd/new_test.go
+++ b/cmd/tempo/variantcmd/new_test.go
@@ -3,8 +3,11 @@ package variantcmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/indaco/tempo/cmd/tempo/componentcmd"
 	"github.com/indaco/tempo/internal/app"
@@ -13,10 +16,11 @@ import (
 	"github.com/indaco/tempo/internal/templatefuncs/providers/gonameprovider"
 	"github.com/indaco/tempo/internal/testhelpers"
 	"github.com/indaco/tempo/internal/testutils"
+	"github.com/indaco/tempo/internal/utils"
 	"github.com/urfave/cli/v3"
 )
 
-func TestVariantNewCommand_DefaultConfig(t *testing.T) {
+func TestVariantCommand_NewSubCmd_DefaultConfig(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Create go.mod inside tempDir (the correct working directory)
@@ -59,7 +63,7 @@ func TestVariantNewCommand_DefaultConfig(t *testing.T) {
 		testutils.ValidateGeneratedFiles(t, expectedFiles)
 	})
 
-	// Step 2: Run "new component" to test the command
+	// Step 2: Run "component new" to test the command
 	t.Run("Create new component with default config", func(t *testing.T) {
 		output, err := testhelpers.CaptureStdout(func() {
 			args := []string{
@@ -87,14 +91,14 @@ func TestVariantNewCommand_DefaultConfig(t *testing.T) {
 		testutils.ValidateGeneratedFiles(t, expectedFiles)
 	})
 
-	// Step 3: Run "define variant" to set up the required folder structure and files
+	// Step 3: Run "variant define" to set up the required folder structure and files
 	t.Run("Define Variant Setup", func(t *testing.T) {
 		_, err := testutils.SetupVariantDefine(app, t)
 		if err != nil {
 			t.Fatalf("Failed to capture stdout: %v", err)
 		}
 
-		// Validate that the "define variant" command generated the expected files
+		// Validate that the "variant define" command generated the expected files
 		expectedFiles := []string{
 			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
 			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
@@ -102,7 +106,7 @@ func TestVariantNewCommand_DefaultConfig(t *testing.T) {
 		testutils.ValidateGeneratedFiles(t, expectedFiles)
 	})
 
-	//Step 4: Run "new variant" to test the command
+	//Step 4: Run "variant new" to test the command
 	t.Run("Variant with default config", func(t *testing.T) {
 		output, err := testhelpers.CaptureStdout(func() {
 			args := []string{
@@ -135,7 +139,7 @@ func TestVariantNewCommand_DefaultConfig(t *testing.T) {
 	})
 }
 
-func TestVariantCommand_WithFlags(t *testing.T) {
+func TestVariantCommand_NewSubCmd_WithFlags(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Create go.mod inside tempDir (the correct working directory)
@@ -176,7 +180,7 @@ func TestVariantCommand_WithFlags(t *testing.T) {
 		}
 	})
 
-	// Step 2: Run "new component" to test the command
+	// Step 2: Run "component new" to test the command
 	t.Run("Component with configs by flags", func(t *testing.T) {
 		output, err := testhelpers.CaptureStdout(func() {
 			args := []string{
@@ -210,14 +214,14 @@ func TestVariantCommand_WithFlags(t *testing.T) {
 		testutils.ValidateGeneratedFiles(t, expectedFiles)
 	})
 
-	// Step 3: Run "define variant" to set up the required folder structure and files
+	// Step 3: Run "variant define" to set up the required folder structure and files
 	t.Run("Define Variant Setup", func(t *testing.T) {
 		_, err := testutils.SetupVariantDefine(app, t)
 		if err != nil {
 			t.Fatalf("Failed to capture stdout: %v", err)
 		}
 
-		// Validate that the "define variant" command generated the expected files
+		// Validate that the "variant define" command generated the expected files
 		expectedFiles := []string{
 			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
 			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
@@ -225,7 +229,7 @@ func TestVariantCommand_WithFlags(t *testing.T) {
 		testutils.ValidateGeneratedFiles(t, expectedFiles)
 	})
 
-	// Step 4: Run "new variant" to test the command
+	// Step 4: Run "variant new" to test the command
 	t.Run("Variant with custom flags", func(t *testing.T) {
 		output, err := testhelpers.CaptureStdout(func() {
 			args := []string{
@@ -263,823 +267,862 @@ func TestVariantCommand_WithFlags(t *testing.T) {
 	})
 }
 
-// func TestHandleEntityExistence(t *testing.T) {
-// 	tests := []struct {
-// 		name         string
-// 		entityType   string
-// 		entityName   string
-// 		outputPath   string
-// 		force        bool
-// 		shouldWarn   bool
-// 		expectedPath string
-// 	}{
-// 		{"Component Exists Without Force", "component", "button", "/mock/path/button", false, true, "/mock/path/button/button"},
-// 		{"Component Exists With Force", "component", "button", "/mock/path/button", true, false, "/mock/path/button/button"},
-// 		{"Variant Exists Without Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", false, true, "/mock/path/button/css/variants/outline.templ"},
-// 		{"Variant Exists With Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", true, false, "/mock/path/button/css/variants/outline.templ"},
-// 		{"Unknown Entity Type", "unknown", "mystery", "/mock/path/unknown", false, true, "/mock/path/unknown"}, // NEW CASE
-// 	}
-
-// 	for _, tc := range tests {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			output, err := testhelpers.CaptureStdout(func() {
-// 				logger := logger.NewDefaultLogger()
-// 				handleEntityExistence(tc.entityType, tc.entityName, tc.outputPath, tc.force, logger)
-// 			})
-
-// 			if err != nil {
-// 				t.Fatalf("Failed to capture stdout: %v", err)
-// 			}
-
-// 			// Verify the warning or overwrite messages
-// 			if tc.shouldWarn {
-// 				if !strings.Contains(output, "Use '--force' to overwrite it.") {
-// 					t.Errorf("Expected warning message, got: %s", output)
-// 				}
-// 			} else {
-// 				if !strings.Contains(output, "Overwriting due to '--force' flag.") {
-// 					t.Errorf("Expected overwrite message, got: %s", output)
-// 				}
-// 			}
-
-// 			// Check if the correct path was used in the log output
-// 			if !strings.Contains(output, tc.expectedPath) {
-// 				t.Errorf("Expected path %q in output, but got: %s", tc.expectedPath, output)
-// 			}
-// 		})
-// 	}
-// }
-
-// func TestNewVariant_CheckComponentExists(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	// Write `tempo.yaml` to the current working directory
-// 	configPath := filepath.Join(tempDir, "tempo.yaml")
-// 	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
-// 		t.Fatalf("Failed to create mock config file: %v", err)
-// 	}
-
-// 	// Prepare CLI app
-// 	app := &cli.Command{
-// 		Commands: []*cli.Command{
-// 			definecmd.SetupDefineCommand(cliCtx),
-// 			SetupNewCommand(cliCtx),
-// 		},
-// 	}
-
-// 	// Step 1: Run "define component" to set up the required folder structure and files
-// 	t.Run("Define Component", func(t *testing.T) {
-// 		_, err := testutils.SetupComponentDefine(app, t)
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		expectedFiles := []string{
-// 			filepath.Join(cfg.Paths.TemplatesDir, "component", "templ", "component.templ.gotxt"),
-// 			filepath.Join(cfg.Paths.ActionsDir, "component.json"),
-// 		}
-// 		testutils.ValidateGeneratedFiles(t, expectedFiles)
-// 	})
-
-// 	// Step 3: Run "define variant" to set up the required folder structure and files
-// 	t.Run("Define Variant Setup", func(t *testing.T) {
-// 		_, err := testutils.SetupVariantDefine(app, t)
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		// Validate that the "define variant" command generated the expected files
-// 		expectedFiles := []string{
-// 			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
-// 			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
-// 		}
-// 		testutils.ValidateGeneratedFiles(t, expectedFiles)
-// 	})
-
-// 	t.Run("Fail Variant Creation When Component Does Not Exist", func(t *testing.T) {
-// 		output, err := testhelpers.CaptureStdout(func() {
-// 			args := []string{
-// 				"tempo", "new", "variant",
-// 				"--name", "ghost",
-// 				"--component", "nonexistent-component",
-// 			}
-// 			if err := app.Run(context.Background(), args); err == nil {
-// 				t.Fatalf("Expected error due to missing component, but got none")
-// 			}
-// 		})
-
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		if !strings.Contains(output, "Cannot create variant: Component does not exist") {
-// 			t.Errorf("Expected missing component error message, got: %s", output)
-// 		}
-// 	})
-// }
-
-// // TestValidateCreateVariantPrerequisites_MissingFolders tests that when required folders are missing,
-// // validateCreateVariantPrerequisites returns an error containing "Missing folders".
-// func TestValidateCreateVariantPrerequisites_MissingFolders(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-// 	// Ensure one of the required folders (e.g. component-variant) is missing.
-// 	variantDir := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
-// 	os.RemoveAll(variantDir)
-
-// 	validate := validateNewVariantPrerequisites(cfg)
-// 	_, err := validate(context.Background(), &cli.Command{})
-// 	if err == nil {
-// 		t.Fatal("Expected an error due to missing folders, but got nil")
-// 	}
-// 	if !strings.Contains(err.Error(), "Missing folders") {
-// 		t.Errorf("Expected error message to mention missing folders, got: %v", err)
-// 	}
-// }
-
-// func TestNewCommandVariant_DryRun(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	// Write `tempo.yaml` to the current working directory
-// 	configPath := filepath.Join(tempDir, "tempo.yaml")
-// 	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
-// 		t.Fatalf("Failed to create mock config file: %v", err)
-// 	}
-
-// 	// Prepare CLI app
-// 	app := &cli.Command{
-// 		Commands: []*cli.Command{
-// 			definecmd.SetupDefineCommand(cliCtx),
-// 			SetupNewCommand(cliCtx),
-// 		},
-// 	}
-
-// 	// Step 1: Run "define component" to set up the required folder structure and files
-// 	t.Run("Define Component", func(t *testing.T) {
-// 		_, err := testutils.SetupComponentDefine(app, t)
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		expectedFiles := []string{
-// 			filepath.Join(cfg.Paths.TemplatesDir, "component", "templ", "component.templ.gotxt"),
-// 			filepath.Join(cfg.Paths.ActionsDir, "component.json"),
-// 		}
-// 		testutils.ValidateGeneratedFiles(t, expectedFiles)
-// 	})
-
-// 	// Step 2: Run "new component" to test the command
-// 	t.Run("Create new component with default config", func(t *testing.T) {
-// 		output, err := testhelpers.CaptureStdout(func() {
-// 			args := []string{
-// 				"tempo", "new", "component",
-// 				"--name", "button",
-// 			}
-// 			if err := app.Run(context.Background(), args); err != nil {
-// 				t.Fatalf("Unexpected error: %v", err)
-// 			}
-// 		})
-
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		testhelpers.ValidateCLIOutput(t, output, []string{
-// 			"✔ Templ component files have been created",
-// 		})
-
-// 		expectedFiles := []string{
-// 			filepath.Join(cfg.App.GoPackage, "button", "button.templ"),
-// 			filepath.Join(cfg.App.GoPackage, "button", "css", "base.templ"),
-// 			filepath.Join(cfg.App.AssetsDir, "button", "css", "base.css"),
-// 		}
-// 		testutils.ValidateGeneratedFiles(t, expectedFiles)
-// 	})
-
-// 	// Step 3: Run "define variant" to set up the required folder structure and files
-// 	t.Run("Define Variant Setup", func(t *testing.T) {
-// 		_, err := testutils.SetupVariantDefine(app, t)
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		// Validate that the "define variant" command generated the expected files
-// 		expectedFiles := []string{
-// 			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
-// 			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
-// 		}
-// 		testutils.ValidateGeneratedFiles(t, expectedFiles)
-// 	})
-
-// 	//Step 4: Run "new variant" to test the command
-// 	t.Run("Variant with default config", func(t *testing.T) {
-// 		output, err := testhelpers.CaptureStdout(func() {
-// 			args := []string{
-// 				"tempo",
-// 				"new",
-// 				"variant",
-// 				"--name", "neon",
-// 				"--component", "button",
-// 				"--dry-run",
-// 			}
-// 			if err := app.Run(context.Background(), args); err != nil {
-// 				t.Fatalf("Unexpected error: %v", err)
-// 			}
-// 		})
-
-// 		if err != nil {
-// 			t.Fatalf("Failed to capture stdout: %v", err)
-// 		}
-
-// 		// Check that the output contains the dry run message.
-// 		if !strings.Contains(output, "Dry Run Mode: No changes will be made.") {
-// 			t.Errorf("Expected dry run message in output, got: %s", output)
-// 		}
-// 	})
-// }
-
-// // createTestComponentCmd returns the CLI command for creating a component.
-// func createTestComponentCmd(cliCtx *app.AppContext) *cli.Command {
-// 	return SetupNewCommand(cliCtx).Commands[0] // component subcommand
-// }
-
-// // createTestVariantCmd returns the CLI command for creating a variant.
-// func createTestVariantCmd(cliCtx *app.AppContext) *cli.Command {
-// 	return SetupNewCommand(cliCtx).Commands[1] // variant subcommand
-// }
-
-// // TestNewComponent_MissingActionsFile tests that if the required component actions file
-// // is missing, the command returns an error with the expected message.
-// func TestNewComponent_MissingActionsFile(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	// Setup config but do not create component.json in the actions folder.
-// 	cfg := config.DefaultConfig()
-// 	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
-// 	cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
-// 	cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
-// 	actionsDir := filepath.Join(cfg.TempoRoot, "actions")
-// 	if err := os.MkdirAll(actionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions folder: %v", err)
-// 	}
-// 	// Ensure component.json is missing.
-// 	os.Remove(filepath.Join(actionsDir, "component.json"))
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestComponentCmd(cliCtx)
-// 	args := []string{
-// 		"tempo", "new", "component",
-// 		"--name", "missingActions",
-// 	}
-// 	err := cmd.Run(context.Background(), args)
-// 	if err == nil {
-// 		t.Fatalf("Expected error due to missing actions file, but got nil")
-// 	}
-// 	// Accept error messages that either mention the specific phrase or list missing folders.
-// 	if !utils.ContainsSubstring(err.Error(), "Cannot find actions folder. Did you run 'tempo define component' before?") &&
-// 		!utils.ContainsSubstring(err.Error(), "Missing folders:") {
-// 		t.Errorf("Unexpected error message: %v", err)
-// 	}
-// }
-
-// // TestNewVariant_MissingActionsFile tests that if the required variant actions file is missing,
-// // the command returns an error with an expected substring.
-// func TestNewVariant_MissingActionsFile(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := config.DefaultConfig()
-// 	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
-// 	cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
-// 	cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
-// 	actionsDir := filepath.Join(cfg.TempoRoot, "actions")
-// 	if err := os.MkdirAll(actionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions folder: %v", err)
-// 	}
-// 	// Ensure variant.json is missing.
-// 	os.Remove(filepath.Join(actionsDir, "variant.json"))
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestVariantCmd(cliCtx)
-// 	args := []string{
-// 		"tempo", "new", "variant",
-// 		"--name", "missingVariantActions",
-// 		"--component", "someComponent",
-// 	}
-// 	err := cmd.Run(context.Background(), args)
-// 	if err == nil {
-// 		t.Fatalf("Expected error due to missing variant actions file, but got nil")
-// 	}
-// 	// Accept error messages that either match the short form or include "Missing folders:".
-// 	if !utils.ContainsSubstring(err.Error(), "Cannot find actions folder. Did you run 'tempo define variant' before?") &&
-// 		!utils.ContainsSubstring(err.Error(), "Missing folders:") {
-// 		t.Errorf("Unexpected error message: %v", err)
-// 	}
-// }
-
-// // TestNewVariant_AlreadyExists_NoForce tests that if the variant file already exists and --force is not provided,
-// // the command returns early without overwriting the file.
-// func TestNewVariant_AlreadyExists_NoForce(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-// 	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
-// 	cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
-// 	cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
-// 	// Create required actions folder and a dummy variant actions file.
-// 	actionsDir := filepath.Join(cfg.TempoRoot, "actions")
-// 	if err := os.MkdirAll(actionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions folder: %v", err)
-// 	}
-// 	variantActionsPath := filepath.Join(actionsDir, "variant.json")
-// 	if err := os.WriteFile(variantActionsPath, []byte("{}"), 0644); err != nil {
-// 		t.Fatalf("Failed to create variant actions file: %v", err)
-// 	}
-
-// 	// Create required template folders so prerequisites pass.
-// 	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
-// 	variantTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
-// 	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create component template directory: %v", err)
-// 	}
-// 	if err := os.MkdirAll(variantTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create variant template directory: %v", err)
-// 	}
-
-// 	// Simulate that the component already exists.
-// 	componentName := "testcomp"
-// 	goPackagePath := cfg.App.GoPackage
-// 	componentPath := filepath.Join(goPackagePath, componentName)
-// 	if err := os.MkdirAll(componentPath, 0755); err != nil {
-// 		t.Fatalf("Failed to create component folder: %v", err)
-// 	}
-// 	// Expected variant output file.
-// 	variantName := "testvar"
-// 	variantOutputPath := filepath.Join(goPackagePath, componentName, "css", "variants", variantName+".templ")
-// 	if err := os.MkdirAll(filepath.Dir(variantOutputPath), 0755); err != nil {
-// 		t.Fatalf("Failed to create variant output folder: %v", err)
-// 	}
-// 	// Create a dummy variant file.
-// 	dummyContent := []byte("dummy content")
-// 	if err := os.WriteFile(variantOutputPath, dummyContent, 0644); err != nil {
-// 		t.Fatalf("Failed to create dummy variant file: %v", err)
-// 	}
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestVariantCmd(cliCtx)
-// 	// Provide flags without --force.
-// 	args := []string{
-// 		"tempo", "new", "variant",
-// 		"--name", variantName,
-// 		"--component", componentName,
-// 	}
-// 	err := cmd.Run(context.Background(), args)
-// 	// Expect nil error because the command should return early.
-// 	if err != nil {
-// 		t.Fatalf("Expected nil error when variant exists without --force, got: %v", err)
-// 	}
-// 	// Verify that the existing variant file was not overwritten.
-// 	contents, err := os.ReadFile(variantOutputPath)
-// 	if err != nil {
-// 		t.Fatalf("Failed to read variant output file: %v", err)
-// 	}
-// 	if string(contents) != string(dummyContent) {
-// 		t.Errorf("Expected variant file to remain unchanged when --force is not provided")
-// 	}
-// }
-
-// func TestNewVariant_ComponentDoesNotExist(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-
-// 	// Ensure required folders exist to pass validation
-// 	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
-// 	variantTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
-// 	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create component template directory: %v", err)
-// 	}
-// 	if err := os.MkdirAll(variantTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create variant template directory: %v", err)
-// 	}
-
-// 	// Ensure actions folder and variant.json exist
-// 	actionsFile := filepath.Join(cfg.Paths.ActionsDir, "variant.json")
-// 	if err := os.MkdirAll(cfg.Paths.ActionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions directory: %v", err)
-// 	}
-// 	if err := os.WriteFile(actionsFile, []byte("{}"), 0644); err != nil {
-// 		t.Fatalf("Failed to create empty actions file: %v", err)
-// 	}
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestVariantCmd(cliCtx)
-// 	args := []string{
-// 		"tempo", "new", "variant",
-// 		"--name", "outline",
-// 		"--component", "nonexistent-component", // This component does not exist
-// 	}
-
-// 	err := cmd.Run(context.Background(), args)
-// 	if err == nil {
-// 		t.Fatalf("Expected error due to missing component, but got nil")
-// 	}
-
-// 	expectedErrorMsg := "Cannot create variant: Component does not exist"
-// 	if !utils.ContainsSubstring(err.Error(), expectedErrorMsg) {
-// 		t.Errorf("Unexpected error message: got %q, expected to contain %q", err.Error(), expectedErrorMsg)
-// 	}
-// }
-
-// func TestNewComponent_CorruptedActionsFile(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-
-// 	// Ensure required folders exist to pass validation
-// 	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
-// 	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create component template directory: %v", err)
-// 	}
-
-// 	// Ensure actions folder exists before writing the corrupted actions file
-// 	actionsDir := cfg.Paths.ActionsDir
-// 	if err := os.MkdirAll(actionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions directory: %v", err)
-// 	}
-
-// 	// Create a corrupted `component.json` file
-// 	actionsFile := filepath.Join(actionsDir, "component.json")
-// 	if err := os.WriteFile(actionsFile, []byte("INVALID_JSON"), 0644); err != nil {
-// 		t.Fatalf("Failed to create corrupted actions file: %v", err)
-// 	}
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestComponentCmd(cliCtx)
-// 	args := []string{
-// 		"tempo", "new", "component",
-// 		"--name", "corrupted",
-// 	}
-
-// 	err := cmd.Run(context.Background(), args)
-// 	if err == nil {
-// 		t.Fatalf("Expected error due to corrupted actions file, but got nil")
-// 	}
-
-// 	// Adjust expected error message based on actual output
-// 	expectedErrorMsg := "failed to process actions for component"
-// 	if !utils.ContainsSubstring(err.Error(), expectedErrorMsg) {
-// 		t.Errorf("Unexpected error message: got %q, expected to contain %q", err.Error(), expectedErrorMsg)
-// 	}
-// }
-
-// func TestNewComponent_UnwritableDirectory(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-
-// 	// Ensure required folders exist to pass validation
-// 	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
-// 	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create component template directory: %v", err)
-// 	}
-
-// 	// Ensure actions folder and `component.json` exist
-// 	actionsDir := cfg.Paths.ActionsDir
-// 	if err := os.MkdirAll(actionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions directory: %v", err)
-// 	}
-// 	actionsFile := filepath.Join(actionsDir, "component.json")
-// 	if err := os.WriteFile(actionsFile, []byte("{}"), 0644); err != nil {
-// 		t.Fatalf("Failed to create actions file: %v", err)
-// 	}
-
-// 	// Create an unwritable target directory
-// 	componentDir := filepath.Join(cfg.App.GoPackage, "unwritable_component")
-// 	if err := os.MkdirAll(componentDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create target directory: %v", err)
-// 	}
-// 	if err := os.Chmod(componentDir, 0000); err != nil {
-// 		t.Fatalf("Failed to make directory unwritable: %v", err)
-// 	}
-// 	defer func() {
-// 		if err := os.Chmod(componentDir, 0755); err != nil {
-// 			t.Errorf("Failed to restore permissions on %s: %v", componentDir, err)
-// 		}
-// 	}()
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestComponentCmd(cliCtx)
-// 	args := []string{
-// 		"tempo", "new", "component",
-// 		"--name", "unwritable_component",
-// 		"--force", // Ensure it tries to write files
-// 	}
-
-// 	err := cmd.Run(context.Background(), args)
-// 	if err == nil {
-// 		t.Fatalf("Expected error due to unwritable directory, but got nil")
-// 	}
-
-// 	expectedErrorMsg := "failed to process actions for component"
-// 	if !utils.ContainsSubstring(err.Error(), expectedErrorMsg) {
-// 		t.Errorf("Unexpected error message: got %q, expected to contain %q", err.Error(), expectedErrorMsg)
-// 	}
-// }
-
-// func TestNewComponent_DryRun_NoChanges(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	// Create go.mod inside tempDir (the correct working directory)
-// 	if err := testutils.CreateModFile(tempDir); err != nil {
-// 		t.Fatalf("Failed to create go.mod file: %v", err)
-// 	}
-
-// 	cfg := setupConfig(tempDir, nil)
-
-// 	// Ensure required template folders exist
-// 	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
-// 	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create component template directory: %v", err)
-// 	}
-
-// 	// Ensure actions folder and `component.json` exist
-// 	actionsDir := cfg.Paths.ActionsDir
-// 	if err := os.MkdirAll(actionsDir, 0755); err != nil {
-// 		t.Fatalf("Failed to create actions directory: %v", err)
-// 	}
-// 	actionsFile := filepath.Join(actionsDir, "component.json")
-// 	if err := os.WriteFile(actionsFile, []byte("{}"), 0644); err != nil {
-// 		t.Fatalf("Failed to create actions file: %v", err)
-// 	}
-
-// 	cliCtx := &app.AppContext{
-// 		Logger: logger.NewDefaultLogger(),
-// 		Config: cfg,
-// 		CWD:    tempDir,
-// 	}
-
-// 	cmd := createTestComponentCmd(cliCtx)
-// 	args := []string{
-// 		"tempo", "new", "component",
-// 		"--name", "dryrun_component",
-// 		"--dry-run",
-// 	}
-
-// 	output, err := testhelpers.CaptureStdout(func() {
-// 		err := cmd.Run(context.Background(), args)
-// 		if err != nil {
-// 			t.Fatalf("Command failed: %v", err)
-// 		}
-// 	})
-
-// 	if err != nil {
-// 		t.Fatalf("Failed to capture stdout: %v", err)
-// 	}
-
-// 	// Validate that the dry-run message appears
-// 	expectedOutput := "Dry Run Mode: No changes will be made."
-// 	if !utils.ContainsSubstring(output, expectedOutput) {
-// 		t.Errorf("Expected output to contain %q, but got: %q", expectedOutput, output)
-// 	}
-
-// 	// Ensure processEntityActions was NOT called (no modifications should happen)
-// 	expectedFailureMsg := "failed to process actions"
-// 	if utils.ContainsSubstring(output, expectedFailureMsg) {
-// 		t.Errorf("Unexpected error during dry-run: %q", output)
-// 	}
-// }
-
-// func TestValidateNewComponentPrerequisites_ErrorOnCheckMissingFolders(t *testing.T) {
-// 	tempDir := t.TempDir()
-// 	cfg := setupConfig(tempDir, nil)
-
-// 	// Mock `CheckMissingFoldersFunc` to simulate a missing folder error
-// 	originalFunc := utils.CheckMissingFoldersFunc
-// 	defer func() { utils.CheckMissingFoldersFunc = originalFunc }() // Restore after test
-
-// 	utils.CheckMissingFoldersFunc = func(folders map[string]string) ([]string, error) {
-// 		return []string{"  - Templates directory: /mock/path/component"}, fmt.Errorf("mock error in CheckMissingFolders")
-// 	}
-
-// 	validate := validateNewComponentPrerequisites(cfg)
-// 	_, err := validate(context.Background(), &cli.Command{})
-
-// 	if err == nil {
-// 		t.Fatal("Expected an error due to CheckMissingFolders failure, but got nil")
-// 	}
-
-// 	// Instead of checking for the mock error, check that the error message contains "Missing folders"
-// 	expectedSubstring := "Missing folders:"
-// 	if !strings.Contains(err.Error(), expectedSubstring) {
-// 		t.Errorf("Expected error message to contain %q, but got %q", expectedSubstring, err.Error())
-// 	}
-// }
-
-// func TestCreateBaseTemplateData_DefaultValues(t *testing.T) {
-// 	tempDir := t.TempDir()
-
-// 	cfg := setupConfig(tempDir, nil)
-
-// 	appCmd := &cli.Command{
-// 		Flags: getCoreFlags(),
-// 	}
-
-// 	// Call function without setting any flags
-// 	data, err := createBaseTemplateData(appCmd, cfg)
-// 	if err != nil {
-// 		t.Fatalf("Expected no error, but got: %v", err)
-// 	}
-
-// 	// Verify defaults
-// 	if data.GoPackage != cfg.App.GoPackage {
-// 		t.Errorf("Expected default GoPackage, got: %s", data.GoPackage)
-// 	}
-// 	if data.AssetsDir != cfg.App.AssetsDir {
-// 		t.Errorf("Expected default AssetsDir, got: %s", data.AssetsDir)
-// 	}
-// 	if data.WithJs != cfg.App.WithJs {
-// 		t.Errorf("Expected default WithJs value, got: %v", data.WithJs)
-// 	}
-// 	if data.Force != false {
-// 		t.Errorf("Expected default Force to be false, got: %v", data.Force)
-// 	}
-// 	if data.DryRun != false {
-// 		t.Errorf("Expected default DryRun to be false, got: %v", data.DryRun)
-// 	}
-// }
-
-// func TestResolveActionFilePath(t *testing.T) {
-// 	tempDir := t.TempDir()
-// 	actionsDir := filepath.Join(tempDir, "actions")
-// 	existingFile := filepath.Join(actionsDir, "existing.json")
-// 	nonExistentFile := filepath.Join(tempDir, "nonexistent.json")
-// 	mockError := fmt.Errorf("mock error")
-
-// 	tests := []struct {
-// 		name           string
-// 		actionsDir     string
-// 		actionFileFlag string
-// 		mockFileExists func(path string) (bool, error)
-// 		expectedErr    string
-// 		expectedResult string
-// 	}{
-// 		{
-// 			name:           "Action file found in ActionsDir",
-// 			actionsDir:     actionsDir,
-// 			actionFileFlag: "existing.json",
-// 			mockFileExists: func(path string) (bool, error) {
-// 				if path == existingFile {
-// 					return true, nil
-// 				}
-// 				return false, nil
-// 			},
-// 			expectedResult: existingFile,
-// 		},
-// 		{
-// 			name:           "Action file does not exist",
-// 			actionsDir:     "",
-// 			actionFileFlag: nonExistentFile,
-// 			mockFileExists: func(path string) (bool, error) {
-// 				return false, nil
-// 			},
-// 			expectedErr: "action file does not exist",
-// 		},
-// 		{
-// 			name:           "Error checking resolvedPath",
-// 			actionsDir:     actionsDir,
-// 			actionFileFlag: "error.json",
-// 			mockFileExists: func(path string) (bool, error) {
-// 				if strings.Contains(path, actionsDir) {
-// 					return false, mockError
-// 				}
-// 				return false, nil
-// 			},
-// 			expectedErr: "mock error",
-// 		},
-// 		{
-// 			name:           "Error checking absolute path",
-// 			actionsDir:     "",
-// 			actionFileFlag: nonExistentFile,
-// 			mockFileExists: func(path string) (bool, error) {
-// 				if path == nonExistentFile {
-// 					return false, mockError
-// 				}
-// 				return false, nil
-// 			},
-// 			expectedErr: "error checking action file path",
-// 		},
-// 	}
-
-// 	for _, tc := range tests {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			// Mock the function
-// 			utils.FileExistsFunc = tc.mockFileExists
-// 			defer func() { utils.FileExistsFunc = utils.FileExists }() // Reset after test
-
-// 			result, err := resolveActionFilePath(tc.actionsDir, tc.actionFileFlag)
-
-// 			if tc.expectedErr != "" {
-// 				if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
-// 					t.Fatalf("Expected error %q, but got: %v", tc.expectedErr, err)
-// 				}
-// 			} else {
-// 				if err != nil {
-// 					t.Fatalf("Unexpected error: %v", err)
-// 				}
-// 				if result != tc.expectedResult {
-// 					t.Fatalf("Expected result %q, but got %q", tc.expectedResult, result)
-// 				}
-// 			}
-// 		})
-// 	}
-// }
+func TestVariantCommand_NewSubComd_DryRun(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Write tempo.yaml to simulate "tempo init"
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+
+	// Prepare the CLI app with the create command.
+	appCmd := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+
+	// Setup the required folders for "define component".
+	t.Run("Define Component Setup", func(t *testing.T) {
+		_, err := testutils.SetupComponentDefine(appCmd, t)
+		if err != nil {
+			t.Fatalf("SetupDefineComponent failed: %v", err)
+		}
+		// Allow some time for filesystem operations.
+		time.Sleep(500 * time.Millisecond)
+	})
+
+	// Run the "component new" command with --dry-run flag.
+	t.Run("Component Dry Run", func(t *testing.T) {
+		_, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo", "component", "new",
+				"--name", "button",
+			}
+			if err := appCmd.Run(context.Background(), args); err != nil {
+				t.Fatalf("Command failed: %v", err)
+			}
+		})
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+	})
+
+	// Step 3: Run "variant define" to set up the required folder structure and files
+	t.Run("Define Variant Setup", func(t *testing.T) {
+		_, err := testutils.SetupVariantDefine(appCmd, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Validate that the "variant define" command generated the expected files
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Run the "component new" command with --dry-run flag.
+	t.Run("Component Dry Run", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo", "variant", "new",
+				"--name", "outline",
+				"--component", "button",
+				"--dry-run",
+			}
+			if err := appCmd.Run(context.Background(), args); err != nil {
+				t.Fatalf("Command failed: %v", err)
+			}
+		})
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Check that the output contains the dry run message.
+		if !strings.Contains(output, "Dry Run Mode: No changes will be made.") {
+			t.Errorf("Expected dry run message in output, got: %s", output)
+		}
+	})
+}
+
+func TestVariantCommand_NewSubCmd_DryRun_NoChanges(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Write `tempo.yaml` to the current working directory
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create mock config file: %v", err)
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+
+	// Step 1: Run "define component" to set up the required folder structure and files
+	t.Run("Define Component", func(t *testing.T) {
+		_, err := testutils.SetupComponentDefine(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component", "templ", "component.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "component.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 2: Run "component new" to test the command
+	t.Run("Create new component with default config", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo", "component", "new",
+				"--name", "button",
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		testhelpers.ValidateCLIOutput(t, output, []string{
+			"✔ Templ component files have been created",
+		})
+
+		expectedFiles := []string{
+			filepath.Join(cfg.App.GoPackage, "button", "button.templ"),
+			filepath.Join(cfg.App.GoPackage, "button", "css", "base.templ"),
+			filepath.Join(cfg.App.AssetsDir, "button", "css", "base.css"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 3: Run "variant define" to set up the required folder structure and files
+	t.Run("Define Variant Setup", func(t *testing.T) {
+		_, err := testutils.SetupVariantDefine(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Validate that the "variant define" command generated the expected files
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	//Step 4: Run "variant new" to test the command
+	t.Run("Variant with default config", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo",
+				"variant",
+				"new",
+				"--name", "neon",
+				"--component", "button",
+				"--dry-run",
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Check that the output contains the dry run message.
+		if !strings.Contains(output, "Dry Run Mode: No changes will be made.") {
+			t.Errorf("Expected dry run message in output, got: %s", output)
+		}
+	})
+}
+
+func TestVariantCommand_NewSubCmd_FailsOnMissingGoMod(t *testing.T) {
+	tempDir := t.TempDir() // Create a temporary directory without go.mod
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Ensure go.mod does NOT exist
+	goModPath := filepath.Join(tempDir, "go.mod")
+	if _, err := os.Stat(goModPath); !os.IsNotExist(err) {
+		t.Fatalf("go.mod file should NOT exist for this test case")
+	}
+
+	// Prepare CLI app
+	appCmd := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+
+	args := []string{"tempo", "variant", "new", "--name", "outline", "--component", "button"}
+
+	// Try running the command
+	err := appCmd.Run(context.Background(), args)
+
+	// Validate error
+	if err == nil {
+		t.Fatal("Expected error due to missing go.mod, but got none")
+	}
+
+	expectedErrorMsg := "missing go.mod file. Run 'go mod init' to create one"
+	if !strings.Contains(err.Error(), expectedErrorMsg) {
+		t.Errorf("Unexpected error message. Expected: %q, got: %q", expectedErrorMsg, err.Error())
+	}
+}
+
+func TestVariantCommand_NewSubCmd_MissingActionsFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
+	cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
+	cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
+	actionsDir := filepath.Join(cfg.TempoRoot, "actions")
+	if err := os.MkdirAll(actionsDir, 0755); err != nil {
+		t.Fatalf("Failed to create actions folder: %v", err)
+	}
+
+	// Write tempo.yaml to simulate "tempo init"
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+
+	// Ensure variant.json is missing.
+	os.Remove(filepath.Join(actionsDir, "variant.json"))
+
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+
+	args := []string{
+		"tempo", "variant", "new",
+		"--name", "missingVariantActions",
+		"--component", "someComponent",
+	}
+	err := app.Run(context.Background(), args)
+	if err == nil {
+		t.Fatalf("Expected error due to missing variant actions file, but got nil")
+	}
+	// Accept error messages that either match the short form or include "Missing folders:".
+	if !utils.ContainsSubstring(err.Error(), "Cannot find actions folder. Did you run 'tempo variant define' before?") &&
+		!utils.ContainsSubstring(err.Error(), "Missing folders:") {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+func TestVariantCommand_NewSubCmd_MissingNameFlag(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, func(cfg *config.Config) {
+		cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
+		cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
+	})
+
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Write `tempo.yaml` to the current working directory
+	configPath := filepath.Join(cliCtx.CWD, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create mock config file: %v", err)
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+
+	// Step 1: Run "define component"
+	t.Run("Define Component Setup", func(t *testing.T) {
+		_, err := testutils.SetupComponentDefine(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+	})
+
+	// Step 2: Run "component new" to test the command
+	t.Run("Component with configs by flags", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo",
+				"component",
+				"new",
+				"--package", cfg.App.GoPackage,
+				"--name", "custom-component",
+				"--assets", cfg.App.AssetsDir,
+			}
+			if err := app.Run(context.Background(), args); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		testhelpers.ValidateCLIOutput(t, output, []string{
+			"✔ Templ component files have been created",
+		})
+
+		//Transform name using the same logic as in the implementation
+		transformedName := gonameprovider.ToGoPackageName("custom-component")
+		expectedFiles := []string{
+			filepath.Join(cfg.App.GoPackage, transformedName, fmt.Sprintf("%s.templ", transformedName)),
+			filepath.Join(cfg.App.GoPackage, transformedName, "css", "base.templ"),
+			filepath.Join(cfg.App.AssetsDir, transformedName, "css", "base.css"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 3: Run "variant define" to set up the required folder structure and files
+	t.Run("Define Variant Setup", func(t *testing.T) {
+		_, err := testutils.SetupVariantDefine(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Validate that the "variant define" command generated the expected files
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 4: Run "variant new" to test the command
+	t.Run("Variant with custom flags", func(t *testing.T) {
+		args := []string{
+			"tempo",
+			"variant",
+			"new",
+			"--package", cfg.App.GoPackage,
+			"--component", "custom-component",
+			"--assets", cfg.App.AssetsDir,
+		}
+
+		err := app.Run(context.Background(), args)
+		if err == nil {
+			t.Fatalf("Expected error due to missing --name flag, but got nil")
+		}
+		expectedErrorMsg := `Required flag "name" not set`
+		if !utils.ContainsSubstring(err.Error(), expectedErrorMsg) {
+			t.Errorf("Unexpected error message: got %q, expected to contain %q", err.Error(), expectedErrorMsg)
+		}
+	})
+}
+
+func TestVariantCommand_NewSubCmd_MissingFolders(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	// Ensure one of the required folders (e.g. component-variant) is missing.
+	variantDir := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
+	os.RemoveAll(variantDir)
+
+	validate := validateVariantNewPrerequisites(cfg)
+	_, err := validate(context.Background(), &cli.Command{})
+	if err == nil {
+		t.Fatal("Expected an error due to missing folders, but got nil")
+	}
+	if !strings.Contains(err.Error(), "Missing folders") {
+		t.Errorf("Expected error message to mention missing folders, got: %v", err)
+	}
+}
+
+func TestVariantCommand_NewSubCmd_CheckComponentExists(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Write `tempo.yaml` to the current working directory
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create mock config file: %v", err)
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+
+	// Step 1: Run "define component" to set up the required folder structure and files
+	t.Run("Define Component", func(t *testing.T) {
+		_, err := testutils.SetupComponentDefine(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component", "templ", "component.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "component.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	// Step 3: Run "variant define" to set up the required folder structure and files
+	t.Run("Define Variant Setup", func(t *testing.T) {
+		_, err := testutils.SetupVariantDefine(app, t)
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		// Validate that the "variant define" command generated the expected files
+		expectedFiles := []string{
+			filepath.Join(cfg.Paths.TemplatesDir, "component-variant", "name.templ.gotxt"),
+			filepath.Join(cfg.Paths.ActionsDir, "variant.json"),
+		}
+		testutils.ValidateGeneratedFiles(t, expectedFiles)
+	})
+
+	t.Run("Fail Variant Creation When Component Does Not Exist", func(t *testing.T) {
+		output, err := testhelpers.CaptureStdout(func() {
+			args := []string{
+				"tempo", "variant", "new",
+				"--name", "ghost",
+				"--component", "nonexistent-component",
+			}
+			if err := app.Run(context.Background(), args); err == nil {
+				t.Fatalf("Expected error due to missing component, but got none")
+			}
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		if !strings.Contains(output, "Cannot create variant: Component does not exist") {
+			t.Errorf("Expected missing component error message, got: %s", output)
+		}
+	})
+}
+
+// !@TODO
+func TestVariantCommand_NewSubCmd_CorruptedActionsFile(t *testing.T) {
+
+}
+
+// !@TODO
+func TestVariantCommand_NewSubCmd_UnwritableDirectory(t *testing.T) {}
+
+func TestVariantCommand_NewSubCmd_AlreadyExists_NoForce(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cfg.TempoRoot = filepath.Join(tempDir, ".tempo-files")
+	cfg.App.GoPackage = filepath.Join(tempDir, "custom-package")
+	cfg.App.AssetsDir = filepath.Join(tempDir, "custom-assets")
+	// Create required actions folder and a dummy variant actions file.
+	actionsDir := filepath.Join(cfg.TempoRoot, "actions")
+	if err := os.MkdirAll(actionsDir, 0755); err != nil {
+		t.Fatalf("Failed to create actions folder: %v", err)
+	}
+
+	// Write tempo.yaml to simulate "tempo init"
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+
+	variantActionsPath := filepath.Join(actionsDir, "variant.json")
+	if err := os.WriteFile(variantActionsPath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("Failed to create variant actions file: %v", err)
+	}
+
+	// Create required template folders so prerequisites pass.
+	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
+	variantTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
+	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
+		t.Fatalf("Failed to create component template directory: %v", err)
+	}
+	if err := os.MkdirAll(variantTemplateDir, 0755); err != nil {
+		t.Fatalf("Failed to create variant template directory: %v", err)
+	}
+
+	// Simulate that the component already exists.
+	componentName := "testcomp"
+	goPackagePath := cfg.App.GoPackage
+	componentPath := filepath.Join(goPackagePath, componentName)
+	if err := os.MkdirAll(componentPath, 0755); err != nil {
+		t.Fatalf("Failed to create component folder: %v", err)
+	}
+	// Expected variant output file.
+	variantName := "testvar"
+	variantOutputPath := filepath.Join(goPackagePath, componentName, "css", "variants", variantName+".templ")
+	if err := os.MkdirAll(filepath.Dir(variantOutputPath), 0755); err != nil {
+		t.Fatalf("Failed to create variant output folder: %v", err)
+	}
+	// Create a dummy variant file.
+	dummyContent := []byte("dummy content")
+	if err := os.WriteFile(variantOutputPath, dummyContent, 0644); err != nil {
+		t.Fatalf("Failed to create dummy variant file: %v", err)
+	}
+
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+	// Provide flags without --force.
+	args := []string{
+		"tempo", "variant", "new",
+		"--name", variantName,
+		"--component", componentName,
+	}
+	err := app.Run(context.Background(), args)
+	// Expect nil error because the command should return early.
+	if err != nil {
+		t.Fatalf("Expected nil error when variant exists without --force, got: %v", err)
+	}
+	// Verify that the existing variant file was not overwritten.
+	contents, err := os.ReadFile(variantOutputPath)
+	if err != nil {
+		t.Fatalf("Failed to read variant output file: %v", err)
+	}
+	if string(contents) != string(dummyContent) {
+		t.Errorf("Expected variant file to remain unchanged when --force is not provided")
+	}
+}
+
+func TestVariantCommand_NewSubCmd_ComponentDoesNotExist(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create go.mod inside tempDir (the correct working directory)
+	if err := testutils.CreateModFile(tempDir); err != nil {
+		t.Fatalf("Failed to create go.mod file: %v", err)
+	}
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+
+	// Ensure required folders exist to pass validation
+	componentTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component")
+	variantTemplateDir := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
+	if err := os.MkdirAll(componentTemplateDir, 0755); err != nil {
+		t.Fatalf("Failed to create component template directory: %v", err)
+	}
+	if err := os.MkdirAll(variantTemplateDir, 0755); err != nil {
+		t.Fatalf("Failed to create variant template directory: %v", err)
+	}
+
+	// Write tempo.yaml to simulate "tempo init"
+	configPath := filepath.Join(tempDir, "tempo.yaml")
+	if err := testutils.WriteConfigToFile(configPath, cfg); err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+
+	// Ensure actions folder and variant.json exist
+	actionsFile := filepath.Join(cfg.Paths.ActionsDir, "variant.json")
+	if err := os.MkdirAll(cfg.Paths.ActionsDir, 0755); err != nil {
+		t.Fatalf("Failed to create actions directory: %v", err)
+	}
+	if err := os.WriteFile(actionsFile, []byte("{}"), 0644); err != nil {
+		t.Fatalf("Failed to create empty actions file: %v", err)
+	}
+
+	cliCtx := &app.AppContext{
+		Logger: logger.NewDefaultLogger(),
+		Config: cfg,
+		CWD:    tempDir,
+	}
+
+	// Prepare CLI app
+	app := &cli.Command{
+		Commands: []*cli.Command{
+			componentcmd.SetupComponentCommand(cliCtx),
+			SetupVariantCommand(cliCtx),
+		},
+	}
+	args := []string{
+		"tempo", "variant", "new",
+		"--name", "outline",
+		"--component", "nonexistent-component", // This component does not exist
+	}
+
+	err := app.Run(context.Background(), args)
+	if err == nil {
+		t.Fatalf("Expected error due to missing component, but got nil")
+	}
+
+	expectedErrorMsg := "Cannot create variant: Component does not exist"
+	if !utils.ContainsSubstring(err.Error(), expectedErrorMsg) {
+		t.Errorf("Unexpected error message: got %q, expected to contain %q", err.Error(), expectedErrorMsg)
+	}
+}
+
+func TestVariantCommand_NewSubCmd_validateVariantNewPrerequisites(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := testutils.SetupConfig(tempDir, nil)
+
+	componentPath := filepath.Join(cfg.Paths.TemplatesDir, "component")
+	variantPath := filepath.Join(cfg.Paths.TemplatesDir, "component-variant")
+
+	tests := []struct {
+		name           string
+		missingFolders map[string]string
+		expectedParts  []string
+	}{
+		{
+			name: "Component directory missing",
+			missingFolders: map[string]string{
+				"Component Directory": componentPath,
+			},
+			expectedParts: []string{
+				"Have you run 'tempo component define' or 'tempo variant define' to set up your components?",
+				"Missing folders:\n  - Component Directory:",
+			},
+		},
+		{
+			name: "Both component and variant directories missing",
+			missingFolders: map[string]string{
+				"Component Directory": componentPath,
+				"Variant Directory":   variantPath,
+			},
+			expectedParts: []string{
+				"Have you run 'tempo component define' or 'tempo variant define' to set up your components?",
+				"Missing folders:",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			validate := validateVariantNewPrerequisites(cfg)
+			_, err := validate(context.Background(), &cli.Command{})
+
+			if len(tt.missingFolders) == 0 {
+				if err != nil {
+					t.Fatalf("Expected no error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("Expected error containing %q, but got nil", tt.expectedParts)
+				}
+
+				for _, expected := range tt.expectedParts {
+					if !utils.ContainsSubstring(err.Error(), expected) {
+						t.Errorf("Expected error message to contain %q, but got: %q", expected, err.Error())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestVariantCommand_NewSubCmd_Func_createBaseTemplateData_DefaultValues(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+
+	appCmd := &cli.Command{
+		Flags: getNewFlags(),
+	}
+
+	// Call function without setting any flags
+	data, err := createBaseTemplateData(appCmd, cfg)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+
+	// Verify defaults
+	if data.GoPackage != cfg.App.GoPackage {
+		t.Errorf("Expected default GoPackage, got: %s", data.GoPackage)
+	}
+	if data.AssetsDir != cfg.App.AssetsDir {
+		t.Errorf("Expected default AssetsDir, got: %s", data.AssetsDir)
+	}
+	if data.Force != false {
+		t.Errorf("Expected default Force to be false, got: %v", data.Force)
+	}
+	if data.DryRun != false {
+		t.Errorf("Expected default DryRun to be false, got: %v", data.DryRun)
+	}
+}
+
+func TestVariantCommand_NewSubCmd_Func_resolveActionFilePath(t *testing.T) {
+	tempDir := t.TempDir()
+	actionsDir := filepath.Join(tempDir, "actions")
+	existingFile := filepath.Join(actionsDir, "existing.json")
+	nonExistentFile := filepath.Join(tempDir, "nonexistent.json")
+	mockError := fmt.Errorf("mock error")
+
+	tests := []struct {
+		name           string
+		actionsDir     string
+		actionFileFlag string
+		mockFileExists func(path string) (bool, error)
+		expectedErr    string
+		expectedResult string
+	}{
+		{
+			name:           "Action file found in ActionsDir",
+			actionsDir:     actionsDir,
+			actionFileFlag: "existing.json",
+			mockFileExists: func(path string) (bool, error) {
+				if path == existingFile {
+					return true, nil
+				}
+				return false, nil
+			},
+			expectedResult: existingFile,
+		},
+		{
+			name:           "Action file does not exist",
+			actionsDir:     "",
+			actionFileFlag: nonExistentFile,
+			mockFileExists: func(path string) (bool, error) {
+				return false, nil
+			},
+			expectedErr: "action file does not exist",
+		},
+		{
+			name:           "Error checking resolvedPath",
+			actionsDir:     actionsDir,
+			actionFileFlag: "error.json",
+			mockFileExists: func(path string) (bool, error) {
+				if strings.Contains(path, actionsDir) {
+					return false, mockError
+				}
+				return false, nil
+			},
+			expectedErr: "mock error",
+		},
+		{
+			name:           "Error checking absolute path",
+			actionsDir:     "",
+			actionFileFlag: nonExistentFile,
+			mockFileExists: func(path string) (bool, error) {
+				if path == nonExistentFile {
+					return false, mockError
+				}
+				return false, nil
+			},
+			expectedErr: "error checking action file path",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock the function
+			utils.FileExistsFunc = tc.mockFileExists
+			defer func() { utils.FileExistsFunc = utils.FileExists }() // Reset after test
+
+			result, err := resolveActionFilePath(tc.actionsDir, tc.actionFileFlag)
+
+			if tc.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("Expected error %q, but got: %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if result != tc.expectedResult {
+					t.Fatalf("Expected result %q, but got %q", tc.expectedResult, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/helpers/errors.go
+++ b/internal/helpers/errors.go
@@ -1,22 +1,37 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/indaco/tempo/internal/templatefuncs/providers/textprovider"
 )
 
-// BuildMissingFoldersError constructs a formatted error message for missing folders.
-func BuildMissingFoldersError(missingFolders []string, contextMsg string, helpCommands []string) error {
-	helpText := ""
-	if len(helpCommands) > 0 {
-		helpText = "\n\n💡 Need help? Run:\n  - " + strings.Join(helpCommands, "\n  - ")
+// BuildMissingFoldersError constructs an error message for missing folders.
+func BuildMissingFoldersError(missingFolders map[string]string, contextMsg string, helpCommands []string) error {
+	if len(missingFolders) == 0 {
+		return nil
 	}
 
-	return fmt.Errorf(
-		`oops! It looks like some required folders are missing.
+	var sb strings.Builder
 
-%s
+	sb.WriteString("oops! It looks like some required folders are missing.\n\n")
+	sb.WriteString(contextMsg)
+	sb.WriteString("\n\nMissing folders:\n")
 
-Missing folders:
-%s%s`, contextMsg, strings.Join(missingFolders, "\n"), helpText)
+	// Append each missing folder entry
+	for name, path := range missingFolders {
+		fmt.Fprintf(&sb, "  - %s: %s\n", textprovider.SnakeToTitle(name), path)
+	}
+
+	// Append help commands if available
+	if len(helpCommands) > 0 {
+		sb.WriteString("\n💡 Need help? Run:\n")
+		for _, cmd := range helpCommands {
+			fmt.Fprintf(&sb, "  - %s\n", cmd)
+		}
+	}
+
+	return errors.New(strings.TrimSpace(sb.String()))
 }

--- a/internal/templatefuncs/providers/textprovider/funcs.go
+++ b/internal/templatefuncs/providers/textprovider/funcs.go
@@ -45,3 +45,12 @@ func TitleCase(word string) string {
 
 	return string(runes)
 }
+
+// SnakeToTitle converts a snake_case string to Title Case.
+func SnakeToTitle(s string) string {
+	words := strings.Split(s, "_")
+	for i, word := range words {
+		words[i] = TitleCase(word)
+	}
+	return strings.Join(words, " ")
+}

--- a/internal/templatefuncs/providers/textprovider/funcs_test.go
+++ b/internal/templatefuncs/providers/textprovider/funcs_test.go
@@ -160,3 +160,32 @@ func TestTitleCase(t *testing.T) {
 		}
 	}
 }
+
+// TestSnakeToTitle tests the SnakeToTitle function.
+func TestSnakeToTitle(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello_world", "Hello World"},
+		{"this_is_a_test", "This Is A Test"},
+		{"snake_case_to_title", "Snake Case To Title"},
+		{"singleword", "Singleword"},
+		{"multiple__underscores", "Multiple  Underscores"},
+		{"_leading_underscore", " Leading Underscore"},
+		{"trailing_underscore_", "Trailing Underscore "},
+		{"", ""},
+		{"__double_leading", "  Double Leading"},
+		{"double_trailing__", "Double Trailing  "},
+		{"a_b_c", "A B C"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := SnakeToTitle(tt.input)
+			if result != tt.expected {
+				t.Errorf("SnakeToTitle(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/utils/entity_check_test.go
+++ b/internal/utils/entity_check_test.go
@@ -148,3 +148,50 @@ func TestVariantCommand_DefineSubCmd_Func_HandleEntityExistence(t *testing.T) {
 		})
 	}
 }
+
+// func TestHandleEntityExistence(t *testing.T) {
+// 	tests := []struct {
+// 		name         string
+// 		entityType   string
+// 		entityName   string
+// 		outputPath   string
+// 		force        bool
+// 		shouldWarn   bool
+// 		expectedPath string
+// 	}{
+// 		{"Component Exists Without Force", "component", "button", "/mock/path/button", false, true, "/mock/path/button/button"},
+// 		{"Component Exists With Force", "component", "button", "/mock/path/button", true, false, "/mock/path/button/button"},
+// 		{"Variant Exists Without Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", false, true, "/mock/path/button/css/variants/outline.templ"},
+// 		{"Variant Exists With Force", "variant", "outline", "/mock/path/button/css/variants/outline.templ", true, false, "/mock/path/button/css/variants/outline.templ"},
+// 		{"Unknown Entity Type", "unknown", "mystery", "/mock/path/unknown", false, true, "/mock/path/unknown"}, // NEW CASE
+// 	}
+
+// 	for _, tc := range tests {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			output, err := testhelpers.CaptureStdout(func() {
+// 				logger := logger.NewDefaultLogger()
+// 				handleEntityExistence(tc.entityType, tc.entityName, tc.outputPath, tc.force, logger)
+// 			})
+
+// 			if err != nil {
+// 				t.Fatalf("Failed to capture stdout: %v", err)
+// 			}
+
+// 			// Verify the warning or overwrite messages
+// 			if tc.shouldWarn {
+// 				if !strings.Contains(output, "Use '--force' to overwrite it.") {
+// 					t.Errorf("Expected warning message, got: %s", output)
+// 				}
+// 			} else {
+// 				if !strings.Contains(output, "Overwriting due to '--force' flag.") {
+// 					t.Errorf("Expected overwrite message, got: %s", output)
+// 				}
+// 			}
+
+// 			// Check if the correct path was used in the log output
+// 			if !strings.Contains(output, tc.expectedPath) {
+// 				t.Errorf("Expected path %q in output, but got: %s", tc.expectedPath, output)
+// 			}
+// 		})
+// 	}
+// }

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"slices"
@@ -131,13 +132,33 @@ func RemoveIfExists(path string) error {
 
 var CheckMissingFoldersFunc = CheckMissingFolders
 
+// CheckMissingFolders validates folder paths and returns a sorted map of missing folders.
 func CheckMissingFolders(folders map[string]string) (map[string]string, error) {
 	missingFolders := make(map[string]string)
 
+	// Collect missing folders
 	for name, path := range folders {
 		if exists, err := DirExists(path); err != nil || !exists {
 			missingFolders[name] = path
 		}
+	}
+
+	// Ensure consistent order by sorting the map keys and reconstructing the map
+	if len(missingFolders) > 0 {
+		sortedKeys := make([]string, 0, len(missingFolders))
+		for name := range missingFolders {
+			sortedKeys = append(sortedKeys, name)
+		}
+
+		sort.Strings(sortedKeys)
+
+		// Reconstruct sorted map
+		sortedMissingFolders := make(map[string]string, len(missingFolders))
+		for _, name := range sortedKeys {
+			sortedMissingFolders[name] = missingFolders[name]
+		}
+
+		return sortedMissingFolders, nil
 	}
 
 	return missingFolders, nil

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"slices"
@@ -130,21 +129,16 @@ func RemoveIfExists(path string) error {
 	return nil
 }
 
-// CheckMissingFoldersFunc is a function variable to allow testing overrides.
 var CheckMissingFoldersFunc = CheckMissingFolders
 
-// CheckMissingFolders validates folder paths and returns a list of missing folders.
-func CheckMissingFolders(folders map[string]string) ([]string, error) {
-	var missingFolders []string
+func CheckMissingFolders(folders map[string]string) (map[string]string, error) {
+	missingFolders := make(map[string]string)
 
 	for name, path := range folders {
 		if exists, err := DirExists(path); err != nil || !exists {
-			missingFolders = append(missingFolders, fmt.Sprintf("  - %s: %s", name, path))
+			missingFolders[name] = path
 		}
 	}
-
-	// Sort the missingFolders slice to ensure consistent order
-	sort.Strings(missingFolders)
 
 	return missingFolders, nil
 }

--- a/internal/utils/fs_test.go
+++ b/internal/utils/fs_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -375,7 +376,7 @@ func TestRemoveIfExists(t *testing.T) {
 }
 
 func TestCheckMissingFolders(t *testing.T) {
-	// Setup: Create temporary directories
+	// Setup: Create a temporary directory
 	tempDir := t.TempDir()
 	existingDir := filepath.Join(tempDir, "existing")
 	if err := os.Mkdir(existingDir, 0755); err != nil {
@@ -385,14 +386,14 @@ func TestCheckMissingFolders(t *testing.T) {
 	tests := []struct {
 		name            string
 		folders         map[string]string
-		expectedMissing []string
+		expectedMissing map[string]string
 	}{
 		{
 			name: "All Folders Exist",
 			folders: map[string]string{
 				"Existing Folder": existingDir,
 			},
-			expectedMissing: nil,
+			expectedMissing: map[string]string{},
 		},
 		{
 			name: "One Missing Folder",
@@ -400,7 +401,9 @@ func TestCheckMissingFolders(t *testing.T) {
 				"Existing Folder": existingDir,
 				"Missing Folder":  filepath.Join(tempDir, "missing"),
 			},
-			expectedMissing: []string{"  - Missing Folder: " + filepath.Join(tempDir, "missing")},
+			expectedMissing: map[string]string{
+				"Missing Folder": filepath.Join(tempDir, "missing"),
+			},
 		},
 		{
 			name: "All Folders Missing",
@@ -408,9 +411,9 @@ func TestCheckMissingFolders(t *testing.T) {
 				"Missing Folder 1": filepath.Join(tempDir, "missing1"),
 				"Missing Folder 2": filepath.Join(tempDir, "missing2"),
 			},
-			expectedMissing: []string{
-				"  - Missing Folder 1: " + filepath.Join(tempDir, "missing1"),
-				"  - Missing Folder 2: " + filepath.Join(tempDir, "missing2"),
+			expectedMissing: map[string]string{
+				"Missing Folder 1": filepath.Join(tempDir, "missing1"),
+				"Missing Folder 2": filepath.Join(tempDir, "missing2"),
 			},
 		},
 	}
@@ -422,14 +425,9 @@ func TestCheckMissingFolders(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
-			if len(missingFolders) != len(tt.expectedMissing) {
-				t.Errorf("Expected %d missing folders, got %d", len(tt.expectedMissing), len(missingFolders))
-			}
-
-			for i, missing := range missingFolders {
-				if missing != tt.expectedMissing[i] {
-					t.Errorf("Expected missing folder: %s, got: %s", tt.expectedMissing[i], missing)
-				}
+			// Compare the actual result with the expected result
+			if !reflect.DeepEqual(missingFolders, tt.expectedMissing) {
+				t.Errorf("Expected missing folders: %+v, got: %+v", tt.expectedMissing, missingFolders)
 			}
 		})
 	}


### PR DESCRIPTION
ThisPR refactors the `CheckMissingFolders` function in the `utils` package to return a map instead of a slice. The change improves the function's efficiency and makes it easier to work with the returned data.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #33 
- <kbd>&nbsp;3&nbsp;</kbd> #32 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #31 
- <kbd>&nbsp;1&nbsp;</kbd> #30 
<!-- GitButler Footer Boundary Bottom -->

