### PR TITLE
docs_cmd_usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ VERSION:
    v0.1.0
 
 COMMANDS:
-   init            Initialize a Tempo project
-   component       Define templates and actions for component or variant
-   variant         Generate a component or variant based on defined templates
-   register        Register is used to extend tempo
-   sync            Process & sync asset files into component templates
-   help            Shows a list of commands or help for one command
+   init       Initialize a Tempo project
+   component  Define reusable component templates and generate instances from them
+   variant    Define component variant templates and create instances based on them
+   register   Register is used to extend tempo.
+   sync       Process & sync asset files into templ components
+   help       Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --help, -h     show help
@@ -170,22 +170,22 @@ Initialize a tempo project by generating a `tempo.yaml` configuration file. This
 
 For a full list of configuration options, See the [Configuration](#️-configuration) section for details.
 
-### define
+### component
 
-Define templates and actions for component or variant
+Define reusable component templates and generate instances from them.
+
+#### Define a Component
 
 ```bash
-tempo define component
-tempo define variant
+tempo component define
 ```
 
-- **component** – Creates a scaffold for defining the structure of a new UI component, including a template and an action file.
-- **variant** – Similar to component, but focused on defining a variant of an existing component (e.g., an _outline_ button variant).
+Creates a scaffold for defining a UI component, including template files and an action JSON file.
 
-These definitions are used later by `tempo new` to generate real instances of components.
+These definitions are later used by `tempo component new` to generate real components.
 
 <details>
-<summary><strong>Flags</strong></summary>
+<summary><strong>Flags</strong> (<code>tempo component define</code>) </summary>
 <dl>
   <dt><code>--force</code></dt>
   <dd>Force overwriting if already exists (<em>default: false</em>)</dd>
@@ -198,26 +198,23 @@ These definitions are used later by `tempo new` to generate real instances of co
 </dl>
 </details>
 
-### new
-
-Generate a component or variant based on defined templates
+#### Generate a Component
 
 ```bash
-tempo new component --name button
-tempo new variant --name outline --component button
+tempo component new --name button
 ```
 
-- **component** – Uses the templates and actions created with tempo define to generate a real component inside assets/ and components/.
-- **variant** – Similar to component, but generates a new variant inside an existing component folder.
+Uses the templates and actions created with `tempo component define` to generate a real component inside _assets/_ and _components/_.
 
-Example: Running `tempo new component --name dropdown` will generate:
+Example: Running `tempo component new --name dropdown` will generate:
 
-- components/dropdown/ (with .templ and .go files).
+- `assets/dropdown/` _(CSS & JS files)_
+- `components/dropdown/` _(with .templ and .go files)_
 
 <details>
-<summary><strong>Component Flags</strong> (<code>tempo new component</code>)</summary>
-<dl>
+<summary><strong>Flags</strong> (<code>tempo component new</code>)</summary>
 
+<dl>
   <dt><code>--package</code> (<code>-p</code>) <em>value</em></dt>
   <dd>The Go package name where components will be generated (<em>default: components</em>)</dd>
 
@@ -238,15 +235,68 @@ Example: Running `tempo new component --name dropdown` will generate:
 </dl>
 </details>
 
-<details>
-<summary><strong>Variant Flags</strong> (<code>tempo new variant</code>)</summary>
+### variant
 
-This command shares all the flags from `new component`, plus:
+Define component variant templates and create instances based on them.
+
+#### Define a Variant
+
+```bash
+tempo variant define
+```
+
+Creates a scaffold for defining a **variant** of an existing component (e.g., an **outline** button variant), including template files and an action JSON file.
+
+These definitions are later used by `tempo variant new` to generate real component variants.
+
+<details>
+<summary><strong>Flags</strong> (<code>tempo variant define</code>) </summary>
 
 <dl>
-  <dt><code>--component</code> (<code>-c</code>) <em>value</em></dt>
-  <dd>Name of the component or entity to which this variant belongs</dd>
+  <dt><code>--force</code></dt>
+  <dd>Force overwriting if the variant definition already exists (<em>default: false</em>)</dd>
+  <dt><code>--dry-run</code></dt>
+  <dd>Preview actions without making changes (<em>default: false</em>)</dd>
 </dl>
+
+</details>
+
+#### Generate a Variant
+
+```bash
+tempo variant new --name outline --component button
+```
+
+Uses the templates and actions created with `tempo variant define` to generate a real instance of a variant inside the corresponding component folder.
+
+Example: Running `tempo variant new --name outline --component` button will generate:
+
+- `components/button/variant/outline.templ`
+- `assets/button/css/variant/outline.css`
+
+<details>
+<summary><strong>Flags</strong> (<code>tempo variant new</code>)</summary>
+
+<dl>
+  <dt><code>--package</code> (<code>-p</code>) <em>value</em></dt>
+  <dd>The Go package name where components will be generated (<em>default: components</em>)</dd>
+
+  <dt><code>--assets</code> (<code>-a</code>) <em>value</em></dt>
+  <dd>The directory where asset files (e.g., CSS, JS) will be generated (<em>default: assets</em>)</dd>
+
+  <dt><code>--name</code> (<code>-n</code>) <em>value</em> <strong>(required)</strong></dt>
+  <dd>The name of the variant being generated</dd>
+
+  <dt><code>--component</code> (<code>-c</code>) <em>value</em> <strong>(required)</strong></dt>
+  <dd>Name of the component or entity to which this variant belongs</dd>
+
+  <dt><code>--force</code></dt>
+  <dd>Force overwriting if the variant already exists (<em>default: false</em>)</dd>
+
+  <dt><code>--dry-run</code></dt>
+  <dd>Preview actions without making changes (<em>default: false</em>)</dd>
+</dl>
+
 </details>
 
 ### register

--- a/cmd/tempo/componentcmd/component.go
+++ b/cmd/tempo/componentcmd/component.go
@@ -10,8 +10,8 @@ import (
 // SetupComponentCommand creates the "component" command with its "define" and "new" subcommand.
 func SetupComponentCommand(cmdCtx *app.AppContext) *cli.Command {
 	return &cli.Command{
-		Name:        "component",
-		Description: "Define reusable component templates and generate instances from them",
+		Name:  "component",
+		Usage: "Define reusable component templates and generate instances from them",
 		Before: func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			return ctx, app.IsTempoProject(cmdCtx.CWD)
 		},

--- a/cmd/tempo/componentcmd/component_test.go
+++ b/cmd/tempo/componentcmd/component_test.go
@@ -27,9 +27,9 @@ func TestSetupComponentCommand(t *testing.T) {
 	}
 
 	// Check Command Description
-	expectedDesc := "Define reusable component templates and generate instances from them"
-	if command.Description != expectedDesc {
-		t.Errorf("Expected description '%s', got '%s'", expectedDesc, command.Description)
+	expectedUsage := "Define reusable component templates and generate instances from them"
+	if command.Usage != expectedUsage {
+		t.Errorf("Expected description '%s', got '%s'", expectedUsage, command.Description)
 	}
 
 	// Check Subcommands Exist

--- a/cmd/tempo/componentcmd/define.go
+++ b/cmd/tempo/componentcmd/define.go
@@ -23,7 +23,7 @@ func setupComponentDefineSubCommand(cmdCtx *app.AppContext) *cli.Command {
 
 	return &cli.Command{
 		Name:                   "define",
-		Description:            "Define a new component template",
+		Usage:                  "Define a new component template",
 		UseShortOptionHandling: true,
 		Flags:                  flags,
 		ArgsUsage:              "[--js] [--force] [--dryrun]",

--- a/cmd/tempo/componentcmd/new.go
+++ b/cmd/tempo/componentcmd/new.go
@@ -23,7 +23,7 @@ func setupComponentNewSubCommand(cmdCtx *app.AppContext) *cli.Command {
 	flags := getNewFlags()
 	return &cli.Command{
 		Name:                   "new",
-		Description:            "Generate a component instance from a template",
+		Usage:                  "Generate a component instance from a template",
 		UseShortOptionHandling: true,
 		Flags:                  flags,
 		ArgsUsage:              "[--package value | -p] [--assets value | -a] [--name value | -n] [--js] [--force] [--dry-run]",

--- a/cmd/tempo/initcmd/init.go
+++ b/cmd/tempo/initcmd/init.go
@@ -26,8 +26,7 @@ func SetupInitCommand(cmdCtx *app.AppContext) *cli.Command {
 
 	return &cli.Command{
 		Name:                   "init",
-		Aliases:                []string{"i"},
-		Description:            "Initialize a Tempo project",
+		Usage:                  "Initialize a Tempo project",
 		UseShortOptionHandling: true,
 		Flags:                  getFlags(),
 		Action:                 runInitCommand(cmdCtx),
@@ -51,6 +50,7 @@ func getFlags() []cli.Flag {
 /* ------------------------------------------------------------------------- */
 /* Command Runner                                                            */
 /* ------------------------------------------------------------------------- */
+
 func runInitCommand(cmdCtx *app.AppContext) func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		const configFileName = "tempo.yaml"

--- a/cmd/tempo/registercmd/register.go
+++ b/cmd/tempo/registercmd/register.go
@@ -21,9 +21,8 @@ import (
 // SetupRegisterCommand sets up the "register" command for registering external functions.
 func SetupRegisterCommand(cmdCtx *app.AppContext) *cli.Command {
 	return &cli.Command{
-		Name:        "register",
-		Aliases:     []string{"r"},
-		Description: "Register is used to extend tempo.",
+		Name:  "register",
+		Usage: "Register is used to extend tempo.",
 		Before: func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			return ctx, app.IsTempoProject(cmdCtx.CWD)
 		},
@@ -80,6 +79,7 @@ func setupRegisterFunctionsSubCommand(cmdCtx *app.AppContext, flags []cli.Flag) 
 /* ------------------------------------------------------------------------- */
 /* Command Runner                                                            */
 /* ------------------------------------------------------------------------- */
+
 func runRegisterFunctionsSubCommand(cmdCtx *app.AppContext) func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		helpers.EnableLoggerIndentation(cmdCtx.Logger)

--- a/cmd/tempo/synccmd/sync.go
+++ b/cmd/tempo/synccmd/sync.go
@@ -27,8 +27,7 @@ import (
 func SetupSyncCommand(cmdCtx *app.AppContext) *cli.Command {
 	return &cli.Command{
 		Name:                   "sync",
-		Description:            "Process & sync asset files into component templates",
-		Aliases:                []string{"s"},
+		Usage:                  "Process & sync asset files into templ components",
 		UseShortOptionHandling: true,
 		Flags:                  getFlags(),
 		ArgsUsage:              "[--input value | -i] [--output value | -o] [--exclude value | -e] [--workers value | -w] [--prod | -p] [--force | -f] [--summary format | -s] [--verbose-summary] [--track-time] [--report-file file | --rf]",
@@ -100,6 +99,7 @@ func getFlags() []cli.Flag {
 /* ------------------------------------------------------------------------- */
 /* Command Runner                                                            */
 /* ------------------------------------------------------------------------- */
+
 func runSyncCommand(cmdCtx *app.AppContext) func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		helpers.EnableLoggerIndentation(cmdCtx.Logger)

--- a/cmd/tempo/variantcmd/define.go
+++ b/cmd/tempo/variantcmd/define.go
@@ -19,7 +19,7 @@ func setupVariantDefineSubCommand(cmdCtx *app.AppContext) *cli.Command {
 
 	return &cli.Command{
 		Name:                   "define",
-		Description:            "Define a new variant template",
+		Usage:                  "Define a new variant template",
 		UseShortOptionHandling: true,
 		Flags:                  flags,
 		ArgsUsage:              "[--force] [--dryrun]",

--- a/cmd/tempo/variantcmd/new.go
+++ b/cmd/tempo/variantcmd/new.go
@@ -21,7 +21,7 @@ func setupVariantNewSubCommand(cmdCtx *app.AppContext) *cli.Command {
 	flags := getNewFlags()
 	return &cli.Command{
 		Name:                   "new",
-		Description:            "Generate a variant instance from a template",
+		Usage:                  "Generate a variant instance from a template",
 		UseShortOptionHandling: true,
 		Flags:                  flags,
 		ArgsUsage:              "[--package value | -p] [--assets value | -a] [--name value | -n] [--component value | -c] [--force] [--dry-run]",
@@ -73,6 +73,7 @@ func getNewFlags() []cli.Flag {
 /* ------------------------------------------------------------------------- */
 /* Command Runner                                                            */
 /* ------------------------------------------------------------------------- */
+
 func runVariantNewSubCommand(cmdCtx *app.AppContext) func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		helpers.EnableLoggerIndentation(cmdCtx.Logger)

--- a/cmd/tempo/variantcmd/variant.go
+++ b/cmd/tempo/variantcmd/variant.go
@@ -10,8 +10,8 @@ import (
 // SetupVariantCommand creates the "component" command with its "define" and "new" subcommand.
 func SetupVariantCommand(cmdCtx *app.AppContext) *cli.Command {
 	return &cli.Command{
-		Name:        "variant",
-		Description: "Define component variant templates and create instances based on them",
+		Name:  "variant",
+		Usage: "Define component variant templates and create instances based on them",
 		Before: func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			return ctx, app.IsTempoProject(cmdCtx.CWD)
 		},

--- a/cmd/tempo/variantcmd/variant_test.go
+++ b/cmd/tempo/variantcmd/variant_test.go
@@ -26,9 +26,9 @@ func TestSetupVariantCommand(t *testing.T) {
 	}
 
 	// Check Command Description
-	expectedDesc := "Define component variant templates and create instances based on them"
-	if command.Description != expectedDesc {
-		t.Errorf("Expected description '%s', got '%s'", expectedDesc, command.Description)
+	expectedUsage := "Define component variant templates and create instances based on them"
+	if command.Usage != expectedUsage {
+		t.Errorf("Expected description '%s', got '%s'", expectedUsage, command.Description)
 	}
 
 	// Check Subcommands Exist


### PR DESCRIPTION
This PR improves the command descriptions and usage text in the `cmd/tempo` package. It also updates the README to reflect the new `component` and `variant` commands.

The changes include:
- Updating the usage text to ensure it reflects the current command options and functionality
- Updating the README to document the new `component` and `variant` commands, including their purpose and usage