### PR TITLE
fix(errors): improve path handling for skipped files in worker

### DIFF
--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/indaco/tempo/internal/utils"
 )
 
 // SkipType defines the type of skipped reason.
@@ -70,12 +72,23 @@ func FormatSkipReason(skipped SkippedFile) ProcessingError {
 	relSource := skipped.Source
 	relDest := skipped.Dest
 
-	// Make paths relative to InputDir and OutputDir
+	// Make source path relative to InputDir
 	if rel, err := filepath.Rel(skipped.InputDir, skipped.Source); err == nil {
-		relSource = rel
+		relSource = filepath.Join(skipped.InputDir, rel) // Ensure base dir is included
 	}
-	if rel, err := filepath.Rel(skipped.OutputDir, skipped.Dest); err == nil {
-		relDest = rel
+
+	// Detect if OutputDir is the current working directory
+	cwd := utils.GetCWD()
+	if skipped.OutputDir == cwd {
+		// Make relDest relative to OutputDir, but remove OutputDir prefix
+		if rel, err := filepath.Rel(skipped.OutputDir, skipped.Dest); err == nil {
+			relDest = rel
+		}
+	} else {
+		// Normal case: make it relative to OutputDir
+		if rel, err := filepath.Rel(skipped.OutputDir, skipped.Dest); err == nil {
+			relDest = filepath.Join(skipped.OutputDir, rel)
+		}
 	}
 
 	return ProcessingError{

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -77,10 +77,9 @@ func FormatSkipReason(skipped SkippedFile) ProcessingError {
 		relSource = filepath.Join(skipped.InputDir, rel) // Ensure base dir is included
 	}
 
-	// Detect if OutputDir is the current working directory
-	cwd := utils.GetCWD()
-	if skipped.OutputDir == cwd {
-		// Make relDest relative to OutputDir, but remove OutputDir prefix
+	// Handle the case when OutputDir is the current working directory (cwd)
+	if skipped.OutputDir == utils.GetCWD() {
+		// Make relDest relative to OutputDir (which is cwd in this case)
 		if rel, err := filepath.Rel(skipped.OutputDir, skipped.Dest); err == nil {
 			relDest = rel
 		}

--- a/internal/worker/errors_test.go
+++ b/internal/worker/errors_test.go
@@ -5,32 +5,47 @@ import (
 	"testing"
 
 	"github.com/indaco/tempo/internal/testhelpers"
+	"github.com/indaco/tempo/internal/utils"
 )
 
 func TestCollectErrors(t *testing.T) {
-	errorsChan := make(chan ProcessingError, 3)
-	expectedErrors := []ProcessingError{
-		{Source: "file1.js", Message: "Syntax error"},
-		{Source: "file2.css", Message: "Invalid property"},
-		{Source: "file3.txt", Reason: "Unsupported file type", SkipType: SkipUnsupportedFile},
-	}
-
-	for _, err := range expectedErrors {
-		errorsChan <- err
-	}
-	close(errorsChan)
-
-	collectedErrors := CollectErrors(errorsChan)
-
-	if len(collectedErrors) != len(expectedErrors) {
-		t.Errorf("Expected %d errors, got %d", len(expectedErrors), len(collectedErrors))
-	}
-
-	for i, err := range collectedErrors {
-		if err != expectedErrors[i] {
-			t.Errorf("Mismatch at index %d: got %+v, expected %+v", i, err, expectedErrors[i])
+	// Test case 1: errorsChan with values
+	t.Run("With values in channel", func(t *testing.T) {
+		errorsChan := make(chan ProcessingError, 3)
+		expectedErrors := []ProcessingError{
+			{Source: "file1.js", Message: "Syntax error"},
+			{Source: "file2.css", Message: "Invalid property"},
+			{Source: "file3.txt", Reason: "Unsupported file type", SkipType: SkipUnsupportedFile},
 		}
-	}
+
+		for _, err := range expectedErrors {
+			errorsChan <- err
+		}
+		close(errorsChan)
+
+		collectedErrors := CollectErrors(errorsChan)
+
+		if len(collectedErrors) != len(expectedErrors) {
+			t.Errorf("Expected %d errors, got %d", len(expectedErrors), len(collectedErrors))
+		}
+
+		for i, err := range collectedErrors {
+			if err != expectedErrors[i] {
+				t.Errorf("Mismatch at index %d: got %+v, expected %+v", i, err, expectedErrors[i])
+			}
+		}
+	})
+
+	// Test case 2: errorsChan is nil
+	t.Run("Nil errorsChan", func(t *testing.T) {
+		var errorsChan <-chan ProcessingError = nil
+
+		collectedErrors := CollectErrors(errorsChan)
+
+		if len(collectedErrors) != 0 {
+			t.Errorf("Expected 0 errors, got %d", len(collectedErrors))
+		}
+	})
 }
 
 func TestFormatError(t *testing.T) {
@@ -45,52 +60,123 @@ func TestFormatError(t *testing.T) {
 }
 
 func TestFormatSkipReason(t *testing.T) {
-	skippedFile := SkippedFile{
-		Source:    "invalid.txt",
-		Dest:      "",
-		InputDir:  "/project/assets",
-		OutputDir: "/project/components",
-		Reason:    "Unsupported file type",
-		SkipType:  SkipUnsupportedFile,
+	//cwd := utils.GetCWD()
+
+	tests := []struct {
+		name        string
+		skipped     SkippedFile
+		expSource   string
+		expDest     string
+		expReason   string
+		expSkipType SkipType
+	}{
+		{
+			name: "Standard case",
+			skipped: SkippedFile{
+				Source:    "assets/js/script.js",
+				Dest:      "components/js/script.templ",
+				InputDir:  "assets",
+				OutputDir: "components",
+				Reason:    "Missing corresponding .templ file in output directory",
+				SkipType:  SkipMissingTemplFile,
+			},
+			expSource:   "assets/js/script.js",
+			expDest:     "components/js/script.templ",
+			expReason:   "Missing corresponding .templ file in output directory",
+			expSkipType: SkipMissingTemplFile,
+		},
+		{
+			name: "OutputDir is the current working directory (cwd)",
+			skipped: SkippedFile{
+				Source:    "assets/js/script.js",
+				Dest:      "js/script.templ",
+				InputDir:  "assets",
+				OutputDir: utils.GetCWD(),
+				Reason:    "Missing corresponding .templ file in output directory",
+				SkipType:  SkipMissingTemplFile,
+			},
+			expSource:   "assets/js/script.js",
+			expDest:     "js/script.templ",
+			expReason:   "Missing corresponding .templ file in output directory",
+			expSkipType: SkipMissingTemplFile,
+		},
+		{
+			name: "OutputDir is the current working directory (.)",
+			skipped: SkippedFile{
+				Source:    "assets/js/script.js",
+				Dest:      "js/script.templ",
+				InputDir:  "assets",
+				OutputDir: ".",
+				Reason:    "Missing corresponding .templ file in output directory",
+				SkipType:  SkipMissingTemplFile,
+			},
+			expSource:   "assets/js/script.js",
+			expDest:     "js/script.templ",
+			expReason:   "Missing corresponding .templ file in output directory",
+			expSkipType: SkipMissingTemplFile,
+		},
 	}
 
-	skip := FormatSkipReason(skippedFile)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skip := FormatSkipReason(tt.skipped)
 
-	if skip.Source != "invalid.txt" {
-		t.Errorf("Expected Source to be 'invalid.txt', got %s", skip.Source)
-	}
-	if skip.Dest != "" {
-		t.Errorf("Expected Dest to be empty, got %s", skip.Dest)
-	}
-	if skip.Reason != "Unsupported file type" {
-		t.Errorf("Expected Reason to be 'Unsupported file type', got %s", skip.Reason)
-	}
-	if skip.SkipType != SkipUnsupportedFile {
-		t.Errorf("Expected SkipType to be '%s', got '%s'", SkipUnsupportedFile, skip.SkipType)
+			if skip.Source != tt.expSource {
+				t.Errorf("Expected Source to be '%s', got '%s'", tt.expSource, skip.Source)
+			}
+			if skip.Dest != tt.expDest {
+				t.Errorf("Expected Dest to be '%s', got '%s'", tt.expDest, skip.Dest)
+			}
+			if skip.Reason != tt.expReason {
+				t.Errorf("Expected Reason to be '%s', got '%s'", tt.expReason, skip.Reason)
+			}
+			if skip.SkipType != tt.expSkipType {
+				t.Errorf("Expected SkipType to be '%s', got '%s'", tt.expSkipType, skip.SkipType)
+			}
+		})
 	}
 }
 
 func TestPrintErrors(t *testing.T) {
-	errors := []ProcessingError{
-		{Source: "file1.js", Message: "Syntax error"},
-		{Source: "file2.css", Message: "Invalid property"},
-		{Source: "ignored.txt", Reason: "Unsupported file type", SkipType: SkipUnsupportedFile},
-	}
+	// Test case 1: errors slice is not empty
+	t.Run("No errors", func(t *testing.T) {
+		errors := []ProcessingError{
+			{Source: "file1.js", Message: "Syntax error"},
+			{Source: "file2.css", Message: "Invalid property"},
+			{Source: "ignored.txt", Reason: "Unsupported file type", SkipType: SkipUnsupportedFile},
+		}
 
-	// Capture output
-	output, err := testhelpers.CaptureStdout(func() {
-		PrintErrors(errors)
+		// Capture output when there are errors
+		output, err := testhelpers.CaptureStdout(func() {
+			PrintErrors(errors)
+		})
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
+
+		expectedMessages := []string{
+			"Errors encountered:",
+			"- File: file1.js\n  Error: Syntax error",
+			"- File: file2.css\n  Error: Invalid property",
+			"- Skipped File: ignored.txt\n  Reason: Unsupported file type (Type: unsupported_file)",
+		}
+
+		testhelpers.ValidateCLIOutput(t, output, expectedMessages)
 	})
-	if err != nil {
-		t.Fatalf("Failed to capture stdout: %v", err)
-	}
 
-	expectedMessages := []string{
-		"Errors encountered:",
-		"- File: file1.js\n  Error: Syntax error",
-		"- File: file2.css\n  Error: Invalid property",
-		"- Skipped File: ignored.txt\n  Reason: Unsupported file type (Type: unsupported_file)",
-	}
+	// Test case 2:  errors slice is empty
+	t.Run("No errors", func(t *testing.T) {
+		// Capture output when there are no errors
+		output, err := testhelpers.CaptureStdout(func() {
+			PrintErrors([]ProcessingError{}) // Empty slice
+		})
+		if err != nil {
+			t.Fatalf("Failed to capture stdout: %v", err)
+		}
 
-	testhelpers.ValidateCLIOutput(t, output, expectedMessages)
+		// Validate that no output is produced
+		if output != "" {
+			t.Errorf("Expected no output, but got: %s", output)
+		}
+	})
 }

--- a/internal/worker/manager_test.go
+++ b/internal/worker/manager_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -83,8 +84,8 @@ func TestWorkerPoolManager_ProcessesJobs(t *testing.T) {
 
 	// Validate expected skipped files
 	expectedSkipped := map[string]string{
-		"button.css": "Missing corresponding .templ file in output directory",
-		"script.js":  "Missing corresponding .templ file in output directory",
+		filepath.Join(opts.InputDir, "button.css"): "Missing corresponding .templ file in output directory",
+		filepath.Join(opts.InputDir, "script.js"):  "Missing corresponding .templ file in output directory",
 	}
 
 	if len(skippedFiles) != len(expectedSkipped) {


### PR DESCRIPTION
Ensure base dir is included in `FormatSkipReason`