### PR TITLE
feat/user-data-template-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - [⚡ Using `tempo sync` as a Standalone Command](#-using-tempo-sync-as-a-standalone-command)
 - [⚙️ Configuration](#️-configuration)
 - [🏗️ Templates & Actions](#️-templates--actions)
-- [🔌 Extending Tempo](#-extending-tempo-with-custom-functions)
+- [🔌 Extending Tempo](#-extending-tempo)
 - [🤝 Contributing](#-contributing)
 - [🆓 License](#-license)
 
@@ -638,7 +638,7 @@ Tempo automatically provides a set of **predefined variables** that can be used 
 
 Tempo supports external function providers, allowing you to integrate additional helper functions into your templates.
 
-See the full guide in [Extending Tempo](#-extending-tempo-with-custom-functions).
+See the full guide in [Extending Tempo](#-extending-tempo).
 
 ### Actions
 
@@ -683,9 +683,48 @@ Each object defines a templating action:
 
 **Variant actions (variant.json) follow the same structure** but target a specific component’s variant subfolder.
 
-## 🔌 Extending Tempo with Custom Functions
+## 🔌 Extending tempo
 
-Tempo allows you to register external function providers, which means you can integrate additional helper functions into your templates.
+`tempo` provides two ways to extend how templates work:
+
+1. **Custom template variables** — enrich templates with additional context using `user_data`.
+2. **Custom template functions** — bring in new helpers via external function providers.
+
+### 🔧 Adding Custom Template Variables
+
+You can pass additional variables to your templates using the `user_data` section in the `tempo.yaml` config file. These variables are accessible inside templates using `.UserData`.
+
+**Example: tempo.yaml**
+
+```yaml
+# ....
+templates:
+  user_data:
+    author: Jane Doe
+    year: 2025
+    config:
+      option1: true
+      option2: false
+```
+
+**Basic Access (dot notation)**
+
+```go
+Author: {{ .UserData.author }}
+Year: {{ .UserData.year }}
+```
+
+**Nested Access**
+
+You can use either:
+
+- `index`(built-in from [text/template](https://pkg.go.dev/text/template))
+- `lookup`(provided by _tempo_, supports dot notation)
+
+```go
+{{ index (index .UserData "config") "option1" }}
+{{ lookup .UserData "config.option1" }}
+```
 
 ### 📦 Using External Function Providers
 

--- a/cmd/tempo/componentcmd/new.go
+++ b/cmd/tempo/componentcmd/new.go
@@ -223,5 +223,6 @@ func createBaseTemplateData(cmd *cli.Command, cfg *config.Config) (*generator.Te
 		GuardMarker:  cfg.Templates.GuardMarker,
 		Force:        isForce,
 		DryRun:       isDryRun,
+		UserData:     cfg.Templates.UserData,
 	}, nil
 }

--- a/cmd/tempo/componentcmd/new_test.go
+++ b/cmd/tempo/componentcmd/new_test.go
@@ -760,4 +760,53 @@ func TestComponentCommand_NewSubCmd_Func_createBaseTemplateData_DefaultValues(t 
 	if data.DryRun != false {
 		t.Errorf("Expected default DryRun to be false, got: %v", data.DryRun)
 	}
+	if data.UserData != nil {
+		t.Errorf("Expected default UserData to be nil, got: %v", data.UserData)
+	}
+}
+
+func TestComponentCommand_NewSubCmd_Func_createBaseTemplateData_UserData(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cfg.Templates.UserData = map[string]any{
+		"author": "Jane Doe",
+		"year":   2025,
+		"config": map[string]any{
+			"option1": "value1",
+		},
+	}
+
+	appCmd := &cli.Command{
+		Flags: getNewFlags(),
+	}
+
+	// Call function without setting any flags
+	data, err := createBaseTemplateData(appCmd, cfg)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+
+	if data.UserData == nil {
+		t.Errorf("Expected default UserData to be not nil, got: %v", data.UserData)
+	}
+
+	author, ok := data.UserData["author"]
+	if !ok || author != "Jane Doe" {
+		t.Errorf("Expected UserData.author = 'Jane Doe', got: %v", author)
+	}
+
+	year, ok := data.UserData["year"]
+	if !ok || year != 2025 {
+		t.Errorf("Expected UserData.year = 2025, got: %v", year)
+	}
+
+	configMap, ok := data.UserData["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected UserData.config to be a map[string]any, got: %T", data.UserData["config"])
+	}
+
+	if val, ok := configMap["option1"]; !ok || val != "value1" {
+		t.Errorf("Expected UserData.config.option1 = 'value1', got: %v", val)
+	}
 }

--- a/cmd/tempo/initcmd/init.go
+++ b/cmd/tempo/initcmd/init.go
@@ -199,6 +199,9 @@ func writeConfigFile(filePath string, cfg *config.Config) error {
 		sb.WriteString(fmt.Sprintf("    # - %s\n", ext))
 	}
 
+	// Add user data section
+	formatUserData(&sb, cfg.Templates.UserData)
+
 	// Add function providers section
 	formatFunctionProviders(&sb, cfg.Templates.FunctionProviders)
 
@@ -209,6 +212,36 @@ func writeConfigFile(filePath string, cfg *config.Config) error {
 /* ------------------------------------------------------------------------- */
 /* Utility Helpers                                                           */
 /* ------------------------------------------------------------------------- */
+
+// formatUserData appends the user_data section to the YAML config.
+func formatUserData(sb *strings.Builder, userData map[string]any) {
+	sb.WriteString("\n  # User-defined variables for template processing.\n")
+	sb.WriteString("  # user_data:\n")
+	sb.WriteString("    # Example flat values\n")
+	sb.WriteString("    # author: John Doe\n")
+	sb.WriteString("    # year: 2025\n")
+	sb.WriteString("    #\n")
+	sb.WriteString("    # Example nested values\n")
+	sb.WriteString("    # config:\n")
+	sb.WriteString("    #   option1: value1\n")
+	sb.WriteString("    #   option2: value2\n")
+
+	// Append actual user data (if any)
+	if len(userData) > 0 {
+		sb.WriteString("  user_data:\n")
+		for key, value := range userData {
+			switch v := value.(type) {
+			case map[string]any:
+				sb.WriteString(fmt.Sprintf("    %s:\n", key))
+				for subKey, subValue := range v {
+					sb.WriteString(fmt.Sprintf("      %s: %v\n", subKey, subValue))
+				}
+			default:
+				sb.WriteString(fmt.Sprintf("    %s: %v\n", key, value))
+			}
+		}
+	}
+}
 
 // formatFunctionProviders appends the function provider settings to the YAML config.
 func formatFunctionProviders(sb *strings.Builder, providers []config.TemplateFuncProvider) {

--- a/cmd/tempo/variantcmd/new.go
+++ b/cmd/tempo/variantcmd/new.go
@@ -245,5 +245,6 @@ func createBaseTemplateData(cmd *cli.Command, cfg *config.Config) (*generator.Te
 		GuardMarker:  cfg.Templates.GuardMarker,
 		Force:        isForce,
 		DryRun:       isDryRun,
+		UserData:     cfg.Templates.UserData,
 	}, nil
 }

--- a/cmd/tempo/variantcmd/new_test.go
+++ b/cmd/tempo/variantcmd/new_test.go
@@ -1032,3 +1032,49 @@ func TestVariantCommand_NewSubCmd_Func_createBaseTemplateData_DefaultValues(t *t
 		t.Errorf("Expected default DryRun to be false, got: %v", data.DryRun)
 	}
 }
+
+func TestVariantCommand_NewSubCmd_Func_createBaseTemplateData_UserData(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := testutils.SetupConfig(tempDir, nil)
+	cfg.Templates.UserData = map[string]any{
+		"author": "Jane Doe",
+		"year":   2025,
+		"config": map[string]any{
+			"option1": "value1",
+		},
+	}
+
+	appCmd := &cli.Command{
+		Flags: getNewFlags(),
+	}
+
+	// Call function without setting any flags
+	data, err := createBaseTemplateData(appCmd, cfg)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+
+	if data.UserData == nil {
+		t.Errorf("Expected default UserData to be not nil, got: %v", data.UserData)
+	}
+
+	author, ok := data.UserData["author"]
+	if !ok || author != "Jane Doe" {
+		t.Errorf("Expected UserData.author = 'Jane Doe', got: %v", author)
+	}
+
+	year, ok := data.UserData["year"]
+	if !ok || year != 2025 {
+		t.Errorf("Expected UserData.year = 2025, got: %v", year)
+	}
+
+	configMap, ok := data.UserData["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected UserData.config to be a map[string]any, got: %T", data.UserData["config"])
+	}
+
+	if val, ok := configMap["option1"]; !ok || val != "value1" {
+		t.Errorf("Expected UserData.config.option1 = 'value1', got: %v", val)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type TemplateFuncProvider struct {
 type Templates struct {
 	Extensions        []string               `yaml:"extensions,omitempty"`
 	GuardMarker       string                 `yaml:"guard_marker,omitempty"`
+	UserData          map[string]any         `yaml:"user_data,omitempty"`
 	FunctionProviders []TemplateFuncProvider `yaml:"function_providers,omitempty"`
 }
 
@@ -144,6 +145,9 @@ func DerivedFolderPaths(baseFolder string) (TemplatesDir, ActionsDir string) {
 // This function updates the default configuration with any non-empty values
 // provided in the fileConfig.
 func ensureDefaults(defaultConfig, fileConfig *Config) *Config {
+	/* --------------------------------------------------------------------- */
+	/* ROOT CONFIG                                                           */
+	/* --------------------------------------------------------------------- */
 	if fileConfig.TempoRoot != "" {
 		resolvedRoot, err := utils.ResolvePath(fileConfig.TempoRoot)
 		if err == nil {
@@ -153,6 +157,9 @@ func ensureDefaults(defaultConfig, fileConfig *Config) *Config {
 		}
 	}
 
+	/* --------------------------------------------------------------------- */
+	/* APP CONFIG                                                            */
+	/* --------------------------------------------------------------------- */
 	if fileConfig.App.GoModule != "" {
 		defaultConfig.App.GoModule = fileConfig.App.GoModule
 	}
@@ -175,6 +182,9 @@ func ensureDefaults(defaultConfig, fileConfig *Config) *Config {
 		}
 	}
 
+	/* --------------------------------------------------------------------- */
+	/* PROCESSOR CONFIG                                                      */
+	/* --------------------------------------------------------------------- */
 	if fileConfig.Processor.Workers != 0 {
 		defaultConfig.Processor.Workers = fileConfig.Processor.Workers
 	}
@@ -182,11 +192,17 @@ func ensureDefaults(defaultConfig, fileConfig *Config) *Config {
 		defaultConfig.Processor.SummaryFormat = fileConfig.Processor.SummaryFormat
 	}
 
+	/* --------------------------------------------------------------------- */
+	/* TEMPLATES CONFIG                                                      */
+	/* --------------------------------------------------------------------- */
 	if len(fileConfig.Templates.Extensions) > 0 {
 		defaultConfig.Templates.Extensions = fileConfig.Templates.Extensions
 	}
 	if fileConfig.Templates.GuardMarker != "" {
 		defaultConfig.Templates.GuardMarker = fileConfig.Templates.GuardMarker
+	}
+	if fileConfig.Templates.UserData != nil {
+		defaultConfig.Templates.UserData = fileConfig.Templates.UserData
 	}
 	if fileConfig.Templates.FunctionProviders != nil {
 		defaultConfig.Templates.FunctionProviders = fileConfig.Templates.FunctionProviders

--- a/internal/generator/template_data.go
+++ b/internal/generator/template_data.go
@@ -28,4 +28,5 @@ type TemplateData struct {
 	GuardMarker   string
 	Force         bool
 	DryRun        bool
+	UserData      map[string]any
 }

--- a/internal/templatefuncs/providers/gonameprovider/provider.go
+++ b/internal/templatefuncs/providers/gonameprovider/provider.go
@@ -6,7 +6,7 @@ import (
 	"github.com/indaco/tempo-api/templatefuncs"
 )
 
-// DefaultProvider implements TemplateFuncProvider
+// GoNameProvider implements TemplateFuncProvider
 type GoNameProvider struct{}
 
 // GetFunctions returns the built-in template functions.
@@ -22,5 +22,5 @@ func (p *GoNameProvider) GetFunctions() template.FuncMap {
 	}
 }
 
-// Expose DefaultProvider as a global instance
+// Expose GoNameProvider as a global instance
 var Provider templatefuncs.TemplateFuncProvider = &GoNameProvider{}

--- a/internal/templatefuncs/providers/gonameprovider/provider_test.go
+++ b/internal/templatefuncs/providers/gonameprovider/provider_test.go
@@ -2,7 +2,7 @@ package gonameprovider
 
 import "testing"
 
-func TestDefaultProvider(t *testing.T) {
+func TestGoNameProvider(t *testing.T) {
 	provider := Provider
 	funcs := provider.GetFunctions()
 

--- a/internal/templatefuncs/providers/lookupprovider/README.md
+++ b/internal/templatefuncs/providers/lookupprovider/README.md
@@ -1,0 +1,7 @@
+# lookupprovider
+
+## Available Template Functions
+
+| Function Name   | Template Function Name | Description                                                      |
+| :-------------- | :--------------------- | :--------------------------------------------------------------- |
+| `Lookup`        | `lookup`               | Retrieves a value from a nested map using a dot-separated key.   |

--- a/internal/templatefuncs/providers/lookupprovider/funcs.go
+++ b/internal/templatefuncs/providers/lookupprovider/funcs.go
@@ -1,0 +1,26 @@
+package lookupprovider
+
+import "strings"
+
+// Lookup retrieves a value from a nested map using a dot-separated key.
+func Lookup(data map[string]any, key string) any {
+	if key == "" {
+		return data
+	}
+
+	keys := strings.Split(key, ".")
+	var value any = data
+
+	for _, k := range keys {
+		if m, ok := value.(map[string]any); ok {
+			if v, exists := m[k]; exists {
+				value = v
+			} else {
+				return nil
+			}
+		} else {
+			return nil
+		}
+	}
+	return value
+}

--- a/internal/templatefuncs/providers/lookupprovider/funcs_test.go
+++ b/internal/templatefuncs/providers/lookupprovider/funcs_test.go
@@ -1,0 +1,113 @@
+package lookupprovider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLookup_ValidKeys(t *testing.T) {
+	testData := map[string]any{
+		"config": map[string]any{
+			"option1": "value1",
+			"option2": "value2",
+			"nested": map[string]any{
+				"key": "deep_value",
+			},
+		},
+		"author": "John Doe",
+		"date":   "2025-03-20",
+	}
+
+	tests := []struct {
+		name     string
+		key      string
+		expected any
+	}{
+		{"Single Level Key", "author", "John Doe"},
+		{"Nested Key", "config.option1", "value1"},
+		{"Deeply Nested Key", "config.nested.key", "deep_value"},
+		{"Another Single Level Key", "date", "2025-03-20"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lookup(testData, tt.key)
+			if result != tt.expected {
+				t.Errorf("lookup(%q) = %v, want %v", tt.key, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLookup_MissingKeys(t *testing.T) {
+	testData := map[string]any{
+		"config": map[string]any{
+			"option1": "value1",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		key      string
+		expected any
+	}{
+		{"Missing Key", "config.unknown", nil},
+		{"Missing Nested Key", "config.nested.unknown", nil},
+		{"Completely Missing Key", "unknownKey", nil},
+		{"Accessing Beyond a String", "config.option1.value", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lookup(testData, tt.key)
+			if result != tt.expected {
+				t.Errorf("lookup(%q) = %v, want %v", tt.key, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLookup_EdgeCases(t *testing.T) {
+	emptyData := map[string]any{}
+
+	tests := []struct {
+		name     string
+		data     map[string]any
+		key      string
+		expected any
+	}{
+		{"Empty Map", emptyData, "someKey", nil},
+		{"Empty Key", map[string]any{"a": "b"}, "", map[string]any{"a": "b"}}, // Should return full map
+		{"Leading Dot", map[string]any{"config": "value"}, ".config", nil},
+		{"Trailing Dot", map[string]any{"config": "value"}, "config.", nil},
+		{"Key with Only Dots", map[string]any{"config": "value"}, "...", nil},
+		//{"Non-String Key", map[string]any{123: "numberKey"}, "123", nil}, // Ensure it doesn't panic
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lookup(tt.data, tt.key)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("lookup(%q) = %v, want %v", tt.key, result, tt.expected)
+			}
+		})
+	}
+}
+
+// func BenchmarkLookup(b *testing.B) {
+// 	testData := map[string]any{
+// 		"config": map[string]any{
+// 			"option1": "value1",
+// 			"nested": map[string]any{
+// 				"key": "deep_value",
+// 			},
+// 		},
+// 		"author": "John Doe",
+// 		"date":   "2025-03-20",
+// 	}
+
+// 	b.ResetTimer()
+// 	for i := 0; i < b.N; i++ {
+// 		_ = Lookup(testData, "config.nested.key")
+// 	}
+// }

--- a/internal/templatefuncs/providers/lookupprovider/provider.go
+++ b/internal/templatefuncs/providers/lookupprovider/provider.go
@@ -1,0 +1,22 @@
+package lookupprovider
+
+import (
+	"text/template"
+
+	"github.com/indaco/tempo-api/templatefuncs"
+)
+
+// LookupProvider implements TemplateFuncProvider
+type LookupProvider struct{}
+
+// GetFunctions returns the built-in template functions.
+// Supported Functions:
+//   - `lookup`: Retrieves a value from a nested map using a dot-separated key.
+func (p *LookupProvider) GetFunctions() template.FuncMap {
+	return template.FuncMap{
+		"lookup": Lookup,
+	}
+}
+
+// Expose LookupProvider as a global instance
+var Provider templatefuncs.TemplateFuncProvider = &LookupProvider{}

--- a/internal/templatefuncs/providers/lookupprovider/provider_test.go
+++ b/internal/templatefuncs/providers/lookupprovider/provider_test.go
@@ -1,0 +1,12 @@
+package lookupprovider
+
+import "testing"
+
+func TestLookupProvider(t *testing.T) {
+	provider := Provider
+	funcs := provider.GetFunctions()
+
+	if _, exists := funcs["lookup"]; !exists {
+		t.Errorf("Expected function 'lookup' to be registered, but it was not found.")
+	}
+}

--- a/internal/templatefuncs/providers/textprovider/README.md
+++ b/internal/templatefuncs/providers/textprovider/README.md
@@ -7,3 +7,4 @@
 | `NormalizePath` | `normalizePath`        | Normalizes a path by removing dots, leading/trailing slashes, and unnecessary white spaces. |
 | `IsEmptyString` | `isEmpty`              | Checks if a given string is empty.                                                          |
 | `TitleCase`     | `titleCase`            | Capitalizes the first letter of a word while preserving the rest of the characters as-is.   |
+| `SnakeToTile`   | `snakeToTitle`         | Converts a snake_case string to Title Case |

--- a/internal/templatefuncs/providers/textprovider/provider.go
+++ b/internal/templatefuncs/providers/textprovider/provider.go
@@ -13,13 +13,16 @@ type TextProvider struct{}
 // Supported Functions:
 //   - `normalizePath`: normalizes a path string.
 //   - `isEmpty`: Checks if a string is empty.
+//   - `titleCase`: Capitalizes the first letter of a word and preserves the rest of the word as-is.
+//   - `isEmpty`: Converts a snake_case string to Title Case.
 func (p *TextProvider) GetFunctions() template.FuncMap {
 	return template.FuncMap{
 		"normalizePath": NormalizePath,
 		"isEmpty":       IsEmptyString,
 		"titleCase":     TitleCase,
+		"snakeToTitle":  SnakeToTitle,
 	}
 }
 
-// Expose DefaultProvider as a global instance
+// Expose TextProvider as a global instance
 var Provider templatefuncs.TemplateFuncProvider = &TextProvider{}

--- a/internal/templatefuncs/providers/textprovider/provider_test.go
+++ b/internal/templatefuncs/providers/textprovider/provider_test.go
@@ -2,7 +2,7 @@ package textprovider
 
 import "testing"
 
-func TestDefaultProvider(t *testing.T) {
+func TestTextProvider(t *testing.T) {
 	provider := Provider
 	funcs := provider.GetFunctions()
 

--- a/internal/utils/renderer.go
+++ b/internal/utils/renderer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/indaco/tempo/internal/errors"
 	"github.com/indaco/tempo/internal/templatefuncs/providers/gonameprovider"
+	"github.com/indaco/tempo/internal/templatefuncs/providers/lookupprovider"
 	"github.com/indaco/tempo/internal/templatefuncs/providers/textprovider"
 	"github.com/indaco/tempo/internal/templatefuncs/registry"
 )
@@ -25,6 +26,7 @@ func RenderTemplate(templateContent string, data any) (string, error) {
 	registerOnce.Do(func() {
 		registry.RegisterFuncProvider(textprovider.Provider)
 		registry.RegisterFuncProvider(gonameprovider.Provider)
+		registry.RegisterFuncProvider(lookupprovider.Provider)
 	})
 
 	// Retrieve all registered functions, including user-defined ones

--- a/internal/utils/renderer_test.go
+++ b/internal/utils/renderer_test.go
@@ -27,6 +27,20 @@ func TestRenderTemplate(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			name:            "Custom function - Title Case",
+			templateContent: "Hello, {{ titleCase .Name }}!",
+			data:            map[string]string{"Name": "wonderful world"},
+			expected:        "Hello, Wonderful world!",
+			expectError:     false,
+		},
+		{
+			name:            "Custom function - snakeToTitle",
+			templateContent: "Hello, {{ snakeToTitle .Name }}!",
+			data:            map[string]string{"Name": "wonderful_world"},
+			expected:        "Hello, Wonderful World!",
+			expectError:     false,
+		},
+		{
 			name:            "Custom function - normalizePath",
 			templateContent: "Normalized: {{ normalizePath .Path }}",
 			data:            map[string]string{"Path": " /folder/./subfolder/../file "},

--- a/internal/utils/renderer_test.go
+++ b/internal/utils/renderer_test.go
@@ -69,6 +69,67 @@ func TestRenderTemplate(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			name:            "Access flat user_data variable",
+			templateContent: "Author: {{ .UserData.author }}, Year: {{ .UserData.year }}",
+			data: map[string]any{
+				"UserData": map[string]any{
+					"author": "Jane Doe",
+					"year":   2025,
+				},
+			},
+			expected:    "Author: Jane Doe, Year: 2025",
+			expectError: false,
+		},
+		{
+			name:            "Custom function - lookup",
+			templateContent: "Option1: {{ lookup .UserData \"config.option1\" }}",
+			data: map[string]any{
+				"UserData": map[string]any{
+					"config": map[string]any{
+						"option1": "value1",
+					},
+				},
+			},
+			expected:    "Option1: value1",
+			expectError: false,
+		},
+		{
+			name:            "Built-in function - index for nested map",
+			templateContent: "Option1: {{ index (index .UserData \"config\") \"option1\" }}",
+			data: map[string]any{
+				"UserData": map[string]any{
+					"config": map[string]any{
+						"option1": "value1",
+					},
+				},
+			},
+			expected:    "Option1: value1",
+			expectError: false,
+		},
+		{
+			name:            "Custom function - lookup with missing key",
+			templateContent: "Missing: {{ lookup .UserData \"config.unknown\" }}",
+			data: map[string]any{
+				"UserData": map[string]any{
+					"config": map[string]any{
+						"option1": "value1",
+					},
+				},
+			},
+			expected:    "Missing: <no value>", // update here
+			expectError: false,
+		},
+		{
+			name:            "Built-in function - index with missing key",
+			templateContent: "Missing: {{ index (index .UserData \"not_a_map\") \"unknown\" }}",
+			data: map[string]any{
+				"UserData": map[string]any{
+					"not_a_map": "string", // not a map, causes error
+				},
+			},
+			expectError: true,
+		},
+		{
 			name:            "Error in template parsing",
 			templateContent: "Hello, {{ .Name ",
 			data:            map[string]string{"Name": "World"},


### PR DESCRIPTION
This PR introduces support for user-defined template data

**Features**

- **Added `snakeToTile` Template Functions:** This new function allows for the conversion of snake_case strings to Title Case.
- **Support for User-Defined Template Data:** Users can now define their own template data through the `user_data`, enabling more customized and dynamic text generation.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #53 
- <kbd>&nbsp;1&nbsp;</kbd> #52 👈 
<!-- GitButler Footer Boundary Bottom -->

