### PR TITLE
fix(component): support conditional JS file generation via OnlyIfJs flag in new subcmd

### DIFF
--- a/internal/generator/action_test.go
+++ b/internal/generator/action_test.go
@@ -894,6 +894,76 @@ func TestProcessEntityActions(t *testing.T) {
 	}
 }
 
+func TestIsJsAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action Action
+		expect bool
+	}{
+		{
+			name: "JS in TemplateFile",
+			action: Action{
+				TemplateFile: "component/assets/js/script.js.gotxt",
+			},
+			expect: true,
+		},
+		{
+			name: "JS in Path",
+			action: Action{
+				Path: "components/button/js/script.templ",
+			},
+			expect: true,
+		},
+		{
+			name: "JS in Source",
+			action: Action{
+				Item:   "folder",
+				Source: "component/assets/js",
+			},
+			expect: true,
+		},
+		{
+			name: "JS in Destination",
+			action: Action{
+				Item:        "folder",
+				Destination: "component/button/js",
+			},
+			expect: true,
+		},
+		{
+			name: "JS in uppercase path (should match)",
+			action: Action{
+				Path: "components/Button/JS/script.templ",
+			},
+			expect: true,
+		},
+		{
+			name: "No JS in any field",
+			action: Action{
+				TemplateFile: "component/assets/css/base.css.gotxt",
+				Path:         "components/button/css/base.templ",
+				Source:       "component/assets/css",
+				Destination:  "components/button/css",
+			},
+			expect: false,
+		},
+		{
+			name:   "Empty action",
+			action: Action{},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isJsAction(tt.action)
+			if result != tt.expect {
+				t.Errorf("isJsAction() = %v, want %v", result, tt.expect)
+			}
+		})
+	}
+}
+
 // UTILITY FUNCTIONS
 
 func fileExists(path string) bool {

--- a/internal/generator/component.go
+++ b/internal/generator/component.go
@@ -60,6 +60,7 @@ func BuildComponentActions(actionType string, force, withJs bool) ([]Action, err
 				Item:         "file",
 				TemplateFile: "component/assets/js/script.js.gotxt",
 				Path:         "{{ .AssetsDir }}/{{ .ComponentName | goPackageName }}/js/script.js",
+				OnlyIfJs:     withJs,
 			},
 			// [JS] - Templ
 			Action{
@@ -67,6 +68,7 @@ func BuildComponentActions(actionType string, force, withJs bool) ([]Action, err
 				Item:         "file",
 				TemplateFile: "component/templ/js/script.templ.gotxt",
 				Path:         "{{ .GoPackage }}/{{ .ComponentName | goPackageName }}/js/script.templ",
+				OnlyIfJs:     withJs,
 			},
 		)
 	}

--- a/internal/generator/component_test.go
+++ b/internal/generator/component_test.go
@@ -78,6 +78,7 @@ func TestBuildComponentActions(t *testing.T) {
 			Item:         "file",
 			TemplateFile: "component/templ/js/script.templ.gotxt",
 			Path:         "{{ .GoPackage }}/{{ .ComponentName | goPackageName }}/js/script.templ",
+			OnlyIfJs:     true,
 		}
 
 		if !reflect.DeepEqual(lastAction, expectedLastAction) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -25,6 +25,11 @@ func ProcessActions(logger logger.LoggerInterface, actions []Action, data *Templ
 			continue
 		}
 
+		// Skip JS-related actions unless OnlyIfJs/WithJs is true
+		if isJsAction(action) && !data.WithJs {
+			continue
+		}
+
 		handler, exists := actionHandlers[action.Type]
 		if !exists {
 			return errors.Wrap("unknown action type", action.Type)


### PR DESCRIPTION
This PR  introduces a new feature that allows for conditional JavaScript files generation in the `component new` subcommand. This enhancement aims to provide flexibility in managin component files and generate JavaScript files only when necessary.

Fix #58