### PR TITLE
ci: remove release note parsing step in favor of softprops body_path

### DIFF
--- a/.github/workflows/release_notes.yaml
+++ b/.github/workflows/release_notes.yaml
@@ -27,19 +27,6 @@ jobs:
             exit 1
           fi
 
-      - name: Read release notes
-        id: read_notes
-        run: |
-          NOTES_FILE=".changes/${{ steps.extract_version.outputs.version }}.md"
-          if [[ -f "$NOTES_FILE" ]]; then
-            RELEASE_NOTES=$(cat "$NOTES_FILE")
-            echo "release_notes<<EOF" >> $GITHUB_OUTPUT
-            echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            exit 1
-          fi
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -49,5 +36,5 @@ jobs:
           prerelease: false
           make_latest: 'true'
           token: ${{ secrets.TEMPO_TOKEN }}
-          body: ${{ steps.read_notes.outputs.release_notes }}
-          generate_release_notes: true
+          body_path: ${{ github.workspace }}/.changes/${{ steps.extract_version.outputs.version }}.md
+          generate_release_notes: false


### PR DESCRIPTION
This PR introduces a change to the `release_notes` workflow by removing the release note parsing step. Instead, we are now utilizing the `softprops body_path` to streamline our workflow.