### PR TITLE
docs(readme): update demo.gif link to point to gh-assets branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 `tempo` is a lightweight CLI for managing assets and scaffolding components in [templ](https://templ.guide)-based projects.
 Inspired by the Italian word for **"time"**, it streamlines CSS & JS workflows while preserving a smooth developer experience.
 
-![tempo](https://tempo.indaco.dev/statics/demo.gif)
+![tempo](https://raw.githubusercontent.com/indaco/tempo/gh-assets/demo.gif)
 
 ## 📚 Documentation
 


### PR DESCRIPTION
This PR moves the demo.gif out of the main branch and into a separate `gh-assets` branch to avoid including large assets in `go install`.

Changes:
- Removed `demo.gif` from the main branch
- Updated `README.md` to reference the hosted GIF from GitHub's raw CDN

This keeps the binary size lean for Go users while preserving visuals in the README.